### PR TITLE
Espace character support in protocol urls

### DIFF
--- a/pkg/url/parse_docker.go
+++ b/pkg/url/parse_docker.go
@@ -47,14 +47,10 @@ func parseDocker(raw string, alpha bool) (*URL, error) {
 	// (it's effectively determined by a configurable regular expression -
 	// NAME_REGEX).
 	var username string
-	for i, r := range raw {
-		if r == '/' {
-			break
-		} else if r == '@' {
-			username = raw[:i]
-			raw = raw[i+1:]
-			break
-		}
+	var err error
+	username, raw, err = splitAndBreak(raw, '@', '/', false,"")
+	if err != nil {
+		return nil, err
 	}
 
 	// Split what remains into the container and the path. Ideally we'd want to
@@ -63,12 +59,9 @@ func parseDocker(raw string, alpha bool) (*URL, error) {
 	// character, but we're better off just allowing Docker to reject container
 	// names that it doesn't like.
 	var container, path string
-	for i, r := range raw {
-		if r == '/' {
-			container = raw[:i]
-			path = raw[i:]
-			break
-		}
+	container, path, err = splitAndBreak(raw, '/', '\x00', true, "")
+	if err != nil {
+		return nil, err
 	}
 	if container == "" {
 		return nil, errors.New("empty container name")

--- a/pkg/url/parse_ssh.go
+++ b/pkg/url/parse_ssh.go
@@ -49,17 +49,10 @@ func parseSCPSSH(raw string) (*URL, error) {
 	// NAME_REGEX). We enforce that if a username is specified, that it is
 	// non-empty.
 	var username string
-	for i, r := range raw {
-		if r == ':' {
-			break
-		} else if r == '@' {
-			if i == 0 {
-				return nil, errors.New("empty username specified")
-			}
-			username = raw[:i]
-			raw = raw[i+1:]
-			break
-		}
+	var err error
+	username, raw, err = splitAndBreak(raw, '@', ':',  false,"username")
+	if err != nil {
+		return nil, err
 	}
 
 	// Parse off the host. Again, ideally we'd want to be a bit more stringent
@@ -71,15 +64,9 @@ func parseSCPSSH(raw string) (*URL, error) {
 	// not found a colon (which indicates that this is probably not an SCP-style
 	// SSH URL).
 	var hostname string
-	for i, r := range raw {
-		if r == ':' {
-			if i == 0 {
-				return nil, errors.New("empty hostname")
-			}
-			hostname = raw[:i]
-			raw = raw[i+1:]
-			break
-		}
+	hostname, raw, err = splitAndBreak(raw, ':', '\x00', false,"hostname")
+	if err != nil {
+		return nil, err
 	}
 	if hostname == "" {
 		return nil, errors.New("no hostname present")

--- a/pkg/url/parse_test.go
+++ b/pkg/url/parse_test.go
@@ -357,6 +357,34 @@ func TestParseSCPSSHUnicodeUsernameHostnamePortPath(t *testing.T) {
 	test.run(t)
 }
 
+func TestParseSCPSSHEscapedUsernameHostnamePathWithAt(t *testing.T) {
+	test := parseTestCase{
+		raw: `user\@vm\:user@host:pa@th`,
+		expected: &URL{
+			Protocol: Protocol_SSH,
+			Username: "user@vm:user",
+			Hostname: "host",
+			Port:     0,
+			Path:     "pa@th",
+		},
+	}
+	test.run(t)
+}
+
+func TestParseSCPSSHUsernameEscapedHostnamePathWithAt(t *testing.T) {
+	test := parseTestCase{
+		raw: `user@vm\:user\@host:pa@th`,
+		expected: &URL{
+			Protocol: Protocol_SSH,
+			Username: "user",
+			Hostname: "vm:user@host",
+			Port:     0,
+			Path:     "pa@th",
+		},
+	}
+	test.run(t)
+}
+
 func TestParseDockerWithBetaSpecificVariables(t *testing.T) {
 	test := parseTestCase{
 		raw:  "docker://cøntainer/пат/to/the file",

--- a/pkg/url/parse_utils.go
+++ b/pkg/url/parse_utils.go
@@ -1,0 +1,30 @@
+package url
+
+import (
+	"errors"
+	"fmt"
+)
+
+// split raw string at first at rune found until breakOn rune is found.
+// It returns the string before at rune, the string between at and breakOn rune, and an error if encountered.
+// If keepAt is true, at rune will be kept inside the second returned value.
+func splitAndBreak(raw string, at rune, breakOn rune, keepAt bool, checkNonEmptyField string) (string, string, error) {
+	var split = ""
+	for i, r := range raw {
+		if r == breakOn {
+			break
+		} else if r == at {
+			split = raw[:i]
+			rawIndex := i
+			if !keepAt {
+				rawIndex += 1
+			}
+			raw = raw[rawIndex:]
+			if i == 0 && len(checkNonEmptyField) > 0 {
+				return split, raw, errors.New(fmt.Sprintf("empty %s specified", checkNonEmptyField))
+			}
+			break
+		}
+	}
+	return split, raw, nil
+}

--- a/pkg/url/parse_utils.go
+++ b/pkg/url/parse_utils.go
@@ -5,26 +5,41 @@ import (
 	"fmt"
 )
 
+const escapeRune = '\\'
+
 // split raw string at first at rune found until breakOn rune is found.
 // It returns the string before at rune, the string between at and breakOn rune, and an error if encountered.
 // If keepAt is true, at rune will be kept inside the second returned value.
-func splitAndBreak(raw string, at rune, breakOn rune, keepAt bool, checkNonEmptyField string) (string, string, error) {
-	var split = ""
+// It supports escape character '\' for at, breakOn and '\' runes.
+func splitAndBreak(raw string, at rune, breakOn rune, keepAt bool, checkEmpty string) (string, string, error) {
+	var split string
+	var escape bool
+
 	for i, r := range raw {
-		if r == breakOn {
-			break
+		if r == escapeRune && !escape {
+			escape = true
+			continue
+		}
+
+		if escape {
+			escape = false
+		} else if r == breakOn {
+			return "", raw, nil
 		} else if r == at {
-			split = raw[:i]
 			rawIndex := i
 			if !keepAt {
 				rawIndex += 1
 			}
 			raw = raw[rawIndex:]
-			if i == 0 && len(checkNonEmptyField) > 0 {
-				return split, raw, errors.New(fmt.Sprintf("empty %s specified", checkNonEmptyField))
+			var err error = nil
+			if len(split) == 0 && len(checkEmpty) > 0 {
+				err = errors.New(fmt.Sprintf("empty %s specified", checkEmpty))
 			}
-			break
+			return split, raw, err
 		}
+
+		split += string(r)
 	}
-	return split, raw, nil
+
+	return "", raw, nil
 }

--- a/pkg/url/parse_utils_test.go
+++ b/pkg/url/parse_utils_test.go
@@ -1,0 +1,198 @@
+package url
+
+import (
+	"testing"
+)
+
+type splitExpected struct {
+	split string
+	raw   string
+	fail  bool
+}
+
+type splitTestCase struct {
+	raw        string
+	at         rune
+	breakOn    rune
+	keepAt     bool
+	checkEmpty string
+	expected   splitExpected
+}
+
+func (c *splitTestCase) run(t *testing.T) {
+	var split, raw, err = splitAndBreak(c.raw, c.at, c.breakOn, c.keepAt, c.checkEmpty)
+
+	if split != c.expected.split {
+		t.Error("split mismatch:", split, "!=", c.expected.split)
+	}
+
+	if raw != c.expected.raw {
+		t.Error("raw mismatch:", raw, "!=", c.expected.raw)
+	}
+
+	if err != nil && !c.expected.fail {
+		t.Fatal("split failed when it should have succeeded:", err)
+	} else if err == nil && c.expected.fail {
+		t.Fatal("split should have failed but did not")
+	}
+}
+
+func TestSplit(t *testing.T) {
+	var testCase = splitTestCase{
+		raw:        `abc@def:ghi`,
+		at:         '@',
+		breakOn:    ':',
+		keepAt:     false,
+		checkEmpty: "",
+		expected: splitExpected{
+			split: "abc",
+			raw:   "def:ghi",
+			fail:  false,
+		},
+	}
+	testCase.run(t)
+}
+
+func TestSplitAtAfterBreak(t *testing.T) {
+	var testCase = splitTestCase{
+		raw:        `abc:def@ghi`,
+		at:         '@',
+		breakOn:    ':',
+		keepAt:     false,
+		checkEmpty: "",
+		expected: splitExpected{
+			split: "",
+			raw:   "abc:def@ghi",
+			fail:  false,
+		},
+	}
+	testCase.run(t)
+}
+
+func TestSplitWithoutCheckEmpty(t *testing.T) {
+	var testCase = splitTestCase{
+		raw:        `@def:ghi`,
+		at:         '@',
+		breakOn:    ':',
+		keepAt:     false,
+		checkEmpty: "",
+		expected: splitExpected{
+			split: "",
+			raw:   "def:ghi",
+			fail:  false,
+		},
+	}
+	testCase.run(t)
+}
+
+func TestSplitWithCheckEmpty(t *testing.T) {
+	var testCase = splitTestCase{
+		raw:        `@def:ghi`,
+		at:         '@',
+		breakOn:    ':',
+		keepAt:     false,
+		checkEmpty: "field",
+		expected: splitExpected{
+			split: "",
+			raw:   "def:ghi",
+			fail:  true,
+		},
+	}
+	testCase.run(t)
+}
+
+func TestSplitEscapeBreak(t *testing.T) {
+	var testCase = splitTestCase{
+		raw:        `abc\:def@ghi`,
+		at:         '@',
+		breakOn:    ':',
+		keepAt:     false,
+		checkEmpty: "",
+		expected: splitExpected{
+			split: "abc:def",
+			raw:   `ghi`,
+			fail:  false,
+		},
+	}
+	testCase.run(t)
+}
+
+func TestSplitDoubleEscape(t *testing.T) {
+	var testCase = splitTestCase{
+		raw:        `abc\@def@\:ghi`,
+		at:         '@',
+		breakOn:    ':',
+		keepAt:     false,
+		checkEmpty: "",
+		expected: splitExpected{
+			split: "abc@def",
+			raw:   `\:ghi`,
+			fail:  false,
+		},
+	}
+	testCase.run(t)
+}
+
+func TestSplitNoBreak(t *testing.T) {
+	var testCase = splitTestCase{
+		raw:        `abc:def`,
+		at:         ':',
+		breakOn:    '\x00',
+		keepAt:     false,
+		checkEmpty: "",
+		expected: splitExpected{
+			split: "abc",
+			raw:   "def",
+			fail:  false,
+		},
+	}
+	testCase.run(t)
+}
+
+func TestSplitNoBreakAndKeepAt(t *testing.T) {
+	var testCase = splitTestCase{
+		raw:        `abc:def`,
+		at:         ':',
+		breakOn:    '\x00',
+		keepAt:     true,
+		checkEmpty: "",
+		expected: splitExpected{
+			split: "abc",
+			raw:   ":def",
+			fail:  false,
+		},
+	}
+	testCase.run(t)
+}
+
+func TestSplitNoMatchWithoutBreak(t *testing.T) {
+	var testCase = splitTestCase{
+		raw:        `abc\:def`,
+		at:         ':',
+		breakOn:    '\x00',
+		keepAt:     false,
+		checkEmpty: "",
+		expected: splitExpected{
+			split: "",
+			raw:   `abc\:def`,
+			fail:  false,
+		},
+	}
+	testCase.run(t)
+}
+
+func TestSplitEscapeNoMatchShouldBreak(t *testing.T) {
+	var testCase = splitTestCase{
+		raw:        `abc:def@test\@test2`,
+		at:         '@',
+		breakOn:    ':',
+		keepAt:     false,
+		checkEmpty: "",
+		expected: splitExpected{
+			split: "",
+			raw:   `abc:def@test\@test2`,
+			fail:  false,
+		},
+	}
+	testCase.run(t)
+}


### PR DESCRIPTION
This is still a work in progress... I discover the go world, first approach is not so pleasant (can't throw errors, no union types, ...), but i'll try to dive in it :p

Currently it's only a refactoring of the parsing of the URLs from docker and ssh/scp protocols, but it should now be easier to implement a common escape character patterns. I'll go on in the evening.