### PR TITLE
Add -mod=readonly to build command in scripts/build.go

### DIFF
--- a/pkg/generate.go
+++ b/pkg/generate.go
@@ -1,4 +1,4 @@
-//go:generate go build github.com/golang/protobuf/protoc-gen-go
+//go:generate go build -mod=readonly github.com/golang/protobuf/protoc-gen-go
 //go:generate protoc --plugin=./protoc-gen-go -I. --go_out=paths=source_relative:. filesystem/behavior/probe_mode.proto
 //go:generate protoc --plugin=./protoc-gen-go -I. --go_out=paths=source_relative:. forwarding/configuration.proto forwarding/session.proto forwarding/socket_overwrite_mode.proto forwarding/state.proto forwarding/version.proto
 //go:generate protoc --plugin=./protoc-gen-go -I. --go_out=paths=source_relative:. forwarding/endpoint/remote/protocol.proto

--- a/scripts/build.go
+++ b/scripts/build.go
@@ -178,7 +178,7 @@ func (t Target) Build(url, output string) error {
 	// binary size and only disables debugging (stack traces are still intact).
 	// For more information, see:
 	// https://blog.filippo.io/shrink-your-go-binaries-with-this-one-weird-trick
-	builder := exec.Command("go", "build", "-o", output, "-ldflags=-s -w", url)
+	builder := exec.Command("go", "build", "-mod=readonly", "-o", output, "-ldflags=-s -w", url)
 
 	// Set the environment.
 	environment, err := t.goEnv()

--- a/scripts/ci/setup_docker.sh
+++ b/scripts/ci/setup_docker.sh
@@ -10,6 +10,7 @@ fi
 # have to disable cgo because to avoid creating dependencies on host libraries
 # that might not exist inside the container.
 CGO_ENABLED=0 go build \
+    -mod=readonly \
     -o "scripts/ci/docker/${TRAVIS_OS_NAME}/httpdemo${EXE_EXT}" \
     github.com/mutagen-io/mutagen/pkg/integration/fixtures/httpdemo
 


### PR DESCRIPTION
This ensures that Go.mod is not modified during the build,
and only frozen dependencies are used.

Without this flag, the build is not reproducible.