### PR TITLE
Fixes (and a tweak) to winfsnotify from Docker Desktop

### DIFF
--- a/pkg/filesystem/watching/internal/third_party/winfsnotify/winfsnotify.go
+++ b/pkg/filesystem/watching/internal/third_party/winfsnotify/winfsnotify.go
@@ -312,6 +312,8 @@ func (w *Watcher) removeWatch(pathname string) error {
 	if err != nil {
 		return err
 	}
+	// We need the volume and index but not the handle itself.
+	syscall.CloseHandle(ino.handle)
 	watch := w.watches.get(ino)
 	if watch == nil {
 		return fmt.Errorf("can't remove non-existent watch for: %s", pathname)

--- a/pkg/filesystem/watching/internal/third_party/winfsnotify/winfsnotify.go
+++ b/pkg/filesystem/watching/internal/third_party/winfsnotify/winfsnotify.go
@@ -95,7 +95,7 @@ type watch struct {
 	mask   uint64            // Directory itself is being watched with these notify flags
 	names  map[string]uint64 // Map of names being watched and their notify flags
 	rename string            // Remembers the old name while renaming a file
-	buf    [16384]byte
+	buf    [65536]byte       // Maximum before we hit network packet limits
 }
 
 type indexMap map[uint64]*watch

--- a/pkg/filesystem/watching/internal/third_party/winfsnotify/winfsnotify.go
+++ b/pkg/filesystem/watching/internal/third_party/winfsnotify/winfsnotify.go
@@ -343,6 +343,9 @@ func (w *Watcher) deleteWatch(watch *watch) {
 	}
 }
 
+// From https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#short-vs-long-names
+const maxExtendedLengthPath = 32767
+
 // Must run within the I/O thread.
 func (w *Watcher) startRead(watch *watch) error {
 	if e := syscall.CancelIo(watch.ino.handle); e != nil {
@@ -449,7 +452,7 @@ func (w *Watcher) readEvents() {
 
 			// Point "raw" to the event in the buffer
 			raw := (*syscall.FileNotifyInformation)(unsafe.Pointer(&watch.buf[offset]))
-			buf := (*[syscall.MAX_PATH]uint16)(unsafe.Pointer(&raw.FileName))
+			buf := (*[maxExtendedLengthPath]uint16)(unsafe.Pointer(&raw.FileName))
 			name := syscall.UTF16ToString(buf[:raw.FileNameLength/2])
 			fullname := filepath.Join(watch.path, name)
 


### PR DESCRIPTION
Here are some small fixes (and a tweak) that I made while testing `winfsnotify` in Docker Desktop. As well as using this code in Mutagen we also use it in the FUSE-based Windows filesharing implementation.

The most interesting one is the fix for long paths (longer than `syscall.MAX_PATH`!) I've added a small test case to demonstrate the issue.

The next one is a handle leak in `removeWatch`. I didn't succeed in making a test case for this unfortunately. For some reason on some machines the leaked handle would prevent a directory being removed and recreated.

The last patch is just to increase the event buffer size to the maximum. I was experiencing quite a lot of event queue overflow so I thought this might be a good idea.