### PR TITLE
[DRAFT] Add HideWindow flag and commented-out CreationFlags

### DIFF
--- a/cmd/mutagen/daemon/start_windows.go
+++ b/cmd/mutagen/daemon/start_windows.go
@@ -2,11 +2,11 @@ package daemon
 
 import (
 	"syscall"
-
-	"github.com/mutagen-io/mutagen/pkg/process"
+	// "github.com/mutagen-io/mutagen/pkg/process"
 )
 
 // daemonProcessAttributes are the process attributes to use for the daemon.
 var daemonProcessAttributes = &syscall.SysProcAttr{
-	CreationFlags: process.DETACHED_PROCESS | syscall.CREATE_NEW_PROCESS_GROUP,
+	// CreationFlags: process.DETACHED_PROCESS | syscall.CREATE_NEW_PROCESS_GROUP,
+	HideWindow: true,
 }

--- a/pkg/process/attributes_windows.go
+++ b/pkg/process/attributes_windows.go
@@ -16,6 +16,7 @@ const (
 // detached processes.
 func DetachedProcessAttributes() *syscall.SysProcAttr {
 	return &syscall.SysProcAttr{
-		CreationFlags: DETACHED_PROCESS,
+		// CreationFlags: DETACHED_PROCESS,
+		HideWindow: true,
 	}
 }


### PR DESCRIPTION
This pull request sets the HideWindow in SysProcAttr to TRUE in order to avoid Mutagen on Windows from generating extra popups.

This PR fixes Issue #233.

SysProcAttr.HideWindow has (presumably) CREATE_NO_WINDOW enabled in CreationFlags.

As you can see from the [MSDN documentation](https://docs.microsoft.com/ja-jp/windows/win32/procthread/process-creation-flags?redirectedfrom=MSDN), CREATE_NO_WINDOW and DETACHED_PROCESS cannot be specified at the same time.

If you enable DETACHED_PROCESS, the problem of popups being generated will continue.

I'm not familiar with the spec, so I think it's up to the developer to decide which flag takes precedence.

I hope this pull request helps the committers!