### PR TITLE
Relocate orchestration lock

### DIFF
--- a/cmd/mutagen/project/flush.go
+++ b/cmd/mutagen/project/flush.go
@@ -40,7 +40,10 @@ func flushMain(_ *cobra.Command, _ []string) error {
 	}
 
 	// Compute the lock path.
-	lockPath := project.LockfilePath(configurationFileName)
+	lockPath, err := project.LockfilePath(configurationFileName)
+	if err != nil {
+		return errors.Wrap(err, "unable to retrieve project lock file path")
+	}
 
 	// Track whether or not we should remove the lock file on return.
 	var removeLockFileOnReturn bool

--- a/cmd/mutagen/project/flush.go
+++ b/cmd/mutagen/project/flush.go
@@ -40,7 +40,7 @@ func flushMain(_ *cobra.Command, _ []string) error {
 	}
 
 	// Compute the lock path.
-	lockPath := configurationFileName + project.LockFileExtension
+	lockPath := project.LockfilePath(configurationFileName)
 
 	// Track whether or not we should remove the lock file on return.
 	var removeLockFileOnReturn bool

--- a/cmd/mutagen/project/list.go
+++ b/cmd/mutagen/project/list.go
@@ -41,7 +41,10 @@ func listMain(_ *cobra.Command, _ []string) error {
 	}
 
 	// Compute the lock path.
-	lockPath := project.LockfilePath(configurationFileName)
+	lockPath, err := project.LockfilePath(configurationFileName)
+	if err != nil {
+		return errors.Wrap(err, "unable to retrieve project lock file path")
+	}
 
 	// Track whether or not we should remove the lock file on return.
 	var removeLockFileOnReturn bool

--- a/cmd/mutagen/project/list.go
+++ b/cmd/mutagen/project/list.go
@@ -41,7 +41,7 @@ func listMain(_ *cobra.Command, _ []string) error {
 	}
 
 	// Compute the lock path.
-	lockPath := configurationFileName + project.LockFileExtension
+	lockPath := project.LockfilePath(configurationFileName)
 
 	// Track whether or not we should remove the lock file on return.
 	var removeLockFileOnReturn bool

--- a/cmd/mutagen/project/pause.go
+++ b/cmd/mutagen/project/pause.go
@@ -41,7 +41,10 @@ func pauseMain(_ *cobra.Command, _ []string) error {
 	}
 
 	// Compute the lock path.
-	lockPath := project.LockfilePath(configurationFileName)
+	lockPath, err := project.LockfilePath(configurationFileName)
+	if err != nil {
+		return errors.Wrap(err, "unable to retrieve project lock file path")
+	}
 
 	// Track whether or not we should remove the lock file on return.
 	var removeLockFileOnReturn bool

--- a/cmd/mutagen/project/pause.go
+++ b/cmd/mutagen/project/pause.go
@@ -41,7 +41,7 @@ func pauseMain(_ *cobra.Command, _ []string) error {
 	}
 
 	// Compute the lock path.
-	lockPath := configurationFileName + project.LockFileExtension
+	lockPath := project.LockfilePath(configurationFileName)
 
 	// Track whether or not we should remove the lock file on return.
 	var removeLockFileOnReturn bool

--- a/cmd/mutagen/project/reset.go
+++ b/cmd/mutagen/project/reset.go
@@ -40,7 +40,10 @@ func resetMain(_ *cobra.Command, _ []string) error {
 	}
 
 	// Compute the lock path.
-	lockPath := project.LockfilePath(configurationFileName)
+	lockPath, err := project.LockfilePath(configurationFileName)
+	if err != nil {
+		return errors.Wrap(err, "unable to retrieve project lock file path")
+	}
 
 	// Track whether or not we should remove the lock file on return.
 	var removeLockFileOnReturn bool

--- a/cmd/mutagen/project/reset.go
+++ b/cmd/mutagen/project/reset.go
@@ -40,7 +40,7 @@ func resetMain(_ *cobra.Command, _ []string) error {
 	}
 
 	// Compute the lock path.
-	lockPath := configurationFileName + project.LockFileExtension
+	lockPath := project.LockfilePath(configurationFileName)
 
 	// Track whether or not we should remove the lock file on return.
 	var removeLockFileOnReturn bool

--- a/cmd/mutagen/project/resume.go
+++ b/cmd/mutagen/project/resume.go
@@ -41,7 +41,7 @@ func resumeMain(_ *cobra.Command, _ []string) error {
 	}
 
 	// Compute the lock path.
-	lockPath := configurationFileName + project.LockFileExtension
+	lockPath := project.LockfilePath(configurationFileName)
 
 	// Track whether or not we should remove the lock file on return.
 	var removeLockFileOnReturn bool

--- a/cmd/mutagen/project/resume.go
+++ b/cmd/mutagen/project/resume.go
@@ -41,7 +41,10 @@ func resumeMain(_ *cobra.Command, _ []string) error {
 	}
 
 	// Compute the lock path.
-	lockPath := project.LockfilePath(configurationFileName)
+	lockPath, err := project.LockfilePath(configurationFileName)
+	if err != nil {
+		return errors.Wrap(err, "unable to retrieve project lock file path")
+	}
 
 	// Track whether or not we should remove the lock file on return.
 	var removeLockFileOnReturn bool

--- a/cmd/mutagen/project/run.go
+++ b/cmd/mutagen/project/run.go
@@ -45,7 +45,7 @@ func runMain(_ *cobra.Command, arguments []string) error {
 	}
 
 	// Compute the lock path.
-	lockPath := configurationFileName + project.LockFileExtension
+	lockPath := project.LockfilePath(configurationFileName)
 
 	// Track whether or not we should remove the lock file on return.
 	var removeLockFileOnReturn bool

--- a/cmd/mutagen/project/run.go
+++ b/cmd/mutagen/project/run.go
@@ -45,7 +45,10 @@ func runMain(_ *cobra.Command, arguments []string) error {
 	}
 
 	// Compute the lock path.
-	lockPath := project.LockfilePath(configurationFileName)
+	lockPath, err := project.LockfilePath(configurationFileName)
+	if err != nil {
+		return errors.Wrap(err, "unable to retrieve project lock file path")
+	}
 
 	// Track whether or not we should remove the lock file on return.
 	var removeLockFileOnReturn bool

--- a/cmd/mutagen/project/start.go
+++ b/cmd/mutagen/project/start.go
@@ -48,7 +48,10 @@ func startMain(_ *cobra.Command, _ []string) error {
 	}
 
 	// Compute the lock path.
-	lockPath := project.LockfilePath(configurationFileName)
+	lockPath, err := project.LockfilePath(configurationFileName)
+	if err != nil {
+		return errors.Wrap(err, "unable to retrieve project lock file path")
+	}
 
 	// Track whether or not we should remove the lock file on return.
 	var removeLockFileOnReturn bool

--- a/cmd/mutagen/project/start.go
+++ b/cmd/mutagen/project/start.go
@@ -48,7 +48,7 @@ func startMain(_ *cobra.Command, _ []string) error {
 	}
 
 	// Compute the lock path.
-	lockPath := configurationFileName + project.LockFileExtension
+	lockPath := project.LockfilePath(configurationFileName)
 
 	// Track whether or not we should remove the lock file on return.
 	var removeLockFileOnReturn bool

--- a/cmd/mutagen/project/terminate.go
+++ b/cmd/mutagen/project/terminate.go
@@ -41,7 +41,7 @@ func terminateMain(_ *cobra.Command, _ []string) error {
 	}
 
 	// Compute the lock path.
-	lockPath := configurationFileName + project.LockFileExtension
+	lockPath := project.LockfilePath(configurationFileName)
 
 	// Track whether or not we should remove the lock file on return.
 	var removeLockFileOnReturn bool

--- a/cmd/mutagen/project/terminate.go
+++ b/cmd/mutagen/project/terminate.go
@@ -41,7 +41,10 @@ func terminateMain(_ *cobra.Command, _ []string) error {
 	}
 
 	// Compute the lock path.
-	lockPath := project.LockfilePath(configurationFileName)
+	lockPath, err := project.LockfilePath(configurationFileName)
+	if err != nil {
+		return errors.Wrap(err, "unable to retrieve project lock file path")
+	}
 
 	// Track whether or not we should remove the lock file on return.
 	var removeLockFileOnReturn bool

--- a/pkg/filesystem/mutagen.go
+++ b/pkg/filesystem/mutagen.go
@@ -14,6 +14,10 @@ const (
 	// inside the user's home directory.
 	MutagenDataDirectoryName = ".mutagen"
 
+	// MutagenProjectLockDirectoryName is the name of the global Mutagen
+	// containing project-level lock files.
+	MutagenProjectLockDirectoryName = "project-locks"
+
 	// MutagenDataDirectoryDevelopmentName is the name of the global Mutagen
 	// data directory inside the user's home directory for development builds of
 	// Mutagen.

--- a/pkg/project/paths.go
+++ b/pkg/project/paths.go
@@ -8,3 +8,7 @@ const (
 	// order to compute the corresponding lock file.
 	LockFileExtension = ".lock"
 )
+
+func LockfilePath(configPath string) string {
+	return configPath + LockFileExtension
+}

--- a/pkg/project/paths.go
+++ b/pkg/project/paths.go
@@ -1,5 +1,11 @@
 package project
 
+import (
+	"crypto/sha1"
+	"fmt"
+	"path/filepath"
+)
+
 const (
 	// DefaultConfigurationFileName is the name of the Mutagen project
 	// configuration file.
@@ -9,6 +15,12 @@ const (
 	LockFileExtension = ".lock"
 )
 
-func LockfilePath(configPath string) string {
-	return configPath + LockFileExtension
+func LockfilePath(configPath string) (string, error) {
+	absConfigPath, err := filepath.Abs(configPath)
+	if err != nil {
+		return "", err
+	}
+
+	absConfigPathHash := fmt.Sprintf("%x", sha1.Sum([]byte(absConfigPath)))
+	return absConfigPathHash + LockFileExtension, nil
 }


### PR DESCRIPTION
This stack of commits moves the lock file location to the mutagen home directory, solving issue 118 (https://github.com/mutagen-io/mutagen/issues/118).

Would appreciate guidance on whether we also need to take migrating the lock file into account (i.e. if it was already created in the repo, and now we check for it in ~/.mutagen/ directory, will this cause problems?).