### PR TITLE
ci: add build timeouts and fix CONTRIBUTING.md permalinks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
     name: Commit Verification
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v2
         with:
@@ -29,6 +30,7 @@ jobs:
   macos:
     name: macOS
     runs-on: macos-11
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -68,6 +70,7 @@ jobs:
   linux:
     name: Linux
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -83,6 +86,7 @@ jobs:
   windows:
     name: Windows
     runs-on: windows-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -105,6 +109,7 @@ jobs:
     name: Sidecar (Non-release)
     runs-on: ubuntu-latest
     if: github.ref_type != 'tag'
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -131,6 +136,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref_type == 'tag'
     needs: [macos, linux, windows]
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -162,6 +168,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref_type == 'tag'
     needs: [macos, linux, windows, sidecar_release]
+    timeout-minutes: 10
     steps:
       - uses: actions/download-artifact@v2
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,9 +65,9 @@ all developers, we kindly request that:
       lines to a reasonable length
 - Comments be used to break up code blocks and be composed of full and complete
   sentences
-  ([example](https://github.com/mutagen-io/mutagen/blob/67a94630f3f6ccf7fe7246b30ad75e68326ca2d1/pkg/synchronization/core/scan.go#L142-L240))
+  ([example](https://github.com/mutagen-io/mutagen/blob/da724cc1946ff70b9734be3bc5f3aae35c818c99/pkg/synchronization/core/scan.go#L142-L240))
 - Imports be grouped by module, with standard library packages in the first
-  group ([example](https://github.com/mutagen-io/mutagen/blob/master/cmd/mutagen/forward/create.go#L3-L25))
+  group ([example](https://github.com/mutagen-io/mutagen/blob/da724cc1946ff70b9734be3bc5f3aae35c818c99/cmd/mutagen/forward/create.go#L3-L25))
 - Non-trivial changes include full test coverage
 
 


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This commit adds some conservative (but reasonable) build timeouts and fixes permalinks in the CONTRIBUTING.md documentation.
