### PR TITLE
sync: trigger event on full inversion with poll-based watching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
   linux:
     name: Linux
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -82,7 +82,7 @@ jobs:
   windows:
     name: Windows
     runs-on: windows-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -105,7 +105,7 @@ jobs:
     name: Sidecar (Non-release)
     runs-on: ubuntu-latest
     if: github.ref_type != 'tag'
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -132,7 +132,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref_type == 'tag'
     needs: [macos, linux, windows]
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,9 +59,9 @@ all developers, we kindly request that:
 - All code be `go fmt`'d
 - New code matches the style and structure of its surrouding code (unless a full
   refactor/rewrite of a package is being performed)
-- Comments be wrapped at 80 columns (with exceptions for long strings like URLs
-  that can't be wrapped)
-    - Code does not need to be wrapped at 80 lines, but please do try to keep
+- Comments be wrapped at 80 columns (including indentation), with exceptions for
+  long strings like URLs that shouldn't be broken across lines
+    - Code does not need to be wrapped at 80 columns, but please do try to keep
       lines to a reasonable length
 - Comments be used to break up code blocks and be composed of full and complete
   sentences

--- a/pkg/synchronization/core/testing_content_test.go
+++ b/pkg/synchronization/core/testing_content_test.go
@@ -87,7 +87,7 @@ func (g *testingContentManager) generate() (string, error) {
 		contentMap: g.baselineContentMap,
 		hasher:     newTestingHasher(),
 	}
-	results, problems, missingFiles := Transition(
+	results, problems, anyChangePerformed, missingFiles := Transition(
 		context.Background(),
 		root,
 		[]*Change{creation},
@@ -99,7 +99,9 @@ func (g *testingContentManager) generate() (string, error) {
 		false,
 		provider,
 	)
-	if missingFiles {
+	if g.baseline != nil && !anyChangePerformed {
+		return "", errors.New("no changes performed for content creation")
+	} else if missingFiles {
 		return "", errors.New("content map missing file definitions")
 	} else if len(problems) > 0 {
 		return "", errors.New("problems encountered during creation")

--- a/pkg/synchronization/core/transition.go
+++ b/pkg/synchronization/core/transition.go
@@ -83,6 +83,9 @@ type transitioner struct {
 	provider Provider
 	// problems are the problems encountered during transition operations.
 	problems []*Problem
+	// anyChangePerformed tracks whether or not any on-disk change was performed
+	// successfully.
+	anyChangePerformed bool
 	// providerMissingFiles indicates that the staged file provider returned an
 	// os.IsNotExist error for at least one file that was expected to be staged.
 	providerMissingFiles bool
@@ -330,8 +333,16 @@ func (t *transitioner) removeFile(parent *filesystem.Directory, name, path strin
 	// The worst case fallout is removal of contents that are modified during
 	// this window.
 
-	// Remove the file.
-	return parent.RemoveFile(name)
+	// Attempt to remove the file.
+	if err := parent.RemoveFile(name); err != nil {
+		return err
+	}
+
+	// Track change operations.
+	t.anyChangePerformed = true
+
+	// Success.
+	return nil
 }
 
 // removeSymbolicLink removes the symbolic link specified by name within the
@@ -353,8 +364,16 @@ func (t *transitioner) removeSymbolicLink(parent *filesystem.Directory, name, pa
 	// filesystem APIs. The worst case fallout is removal of contents that are
 	// modified during this window.
 
-	// Remove the symbolic link.
-	return parent.RemoveSymbolicLink(name)
+	// Attempt to remove the symbolic link.
+	if err := parent.RemoveSymbolicLink(name); err != nil {
+		return err
+	}
+
+	// Track change operations.
+	t.anyChangePerformed = true
+
+	// Success.
+	return nil
 }
 
 // removeDirectory (recursively) removes the directory specified by name within
@@ -485,6 +504,7 @@ ContentLoop:
 		if err := parent.RemoveDirectory(name); err != nil {
 			t.recordProblem(path, fmt.Errorf("unable to remove directory: %w", err))
 		} else {
+			t.anyChangePerformed = true
 			return true
 		}
 	}
@@ -580,6 +600,7 @@ func (t *transitioner) findAndMoveStagedFileIntoPlace(
 	// Attempt to atomically rename the file. If we succeed, we're done.
 	renameErr := filesystem.Rename(nil, stagedPath, parent, name, replace)
 	if renameErr == nil {
+		t.anyChangePerformed = true
 		return nil
 	}
 
@@ -647,6 +668,9 @@ func (t *transitioner) findAndMoveStagedFileIntoPlace(
 		return fmt.Errorf("unable to relocate intermediate file: %w", err)
 	}
 
+	// Track changes operations.
+	t.anyChangePerformed = true
+
 	// Remove the staged file. We don't bother checking for errors because
 	// there's not much we can or need to do about them at this point.
 	os.Remove(stagedPath)
@@ -699,6 +723,9 @@ func (t *transitioner) swapFile(path string, oldEntry, newEntry *Entry) error {
 			return fmt.Errorf("unable to change file permissions: %w", err)
 		}
 
+		// Track change operations.
+		t.anyChangePerformed = true
+
 		// Success.
 		return nil
 	}
@@ -727,6 +754,9 @@ func (t *transitioner) createSymbolicLink(parent *filesystem.Directory, name, pa
 	if err := parent.CreateSymbolicLink(name, target.Target); err != nil {
 		return err
 	}
+
+	// Track change operations.
+	t.anyChangePerformed = true
 
 	// RACE: There is a race condition here between the creation of the symbolic
 	// link and the setting of its ownership/permissions that we have to live
@@ -767,6 +797,9 @@ func (t *transitioner) createDirectory(parent *filesystem.Directory, name, path 
 		t.recordProblem(path, fmt.Errorf("unable to create directory: %w", err))
 		return nil
 	}
+
+	// Track change operations.
+	t.anyChangePerformed = true
 
 	// Create a shallow copy of the target that we'll populate as we create its
 	// contents.
@@ -905,7 +938,7 @@ func Transition(
 	defaultOwnership *filesystem.OwnershipSpecification,
 	recomposeUnicode bool,
 	provider Provider,
-) ([]*Entry, []*Problem, bool) {
+) ([]*Entry, []*Problem, bool, bool) {
 	// Extract the cancellation channel.
 	cancelled := ctx.Done()
 
@@ -972,5 +1005,5 @@ func Transition(
 	}
 
 	// Done.
-	return results, transitioner.problems, transitioner.providerMissingFiles
+	return results, transitioner.problems, transitioner.anyChangePerformed, transitioner.providerMissingFiles
 }

--- a/pkg/synchronization/core/transition_test.go
+++ b/pkg/synchronization/core/transition_test.go
@@ -94,6 +94,9 @@ func TestTransition(t *testing.T) {
 		// expectedProblems are the expected problems. Their order is not
 		// important since they'll be compared with testingProblemListsEqual.
 		expectedProblems []*Problem
+		// expectAnyChangePerformed indicates whether or not change is expected
+		// to be performed successfully.
+		expectAnyChangePerformed bool
 		// expectMissingFiles indicates whether or not files are expected to be
 		// missing from the provider.
 		expectMissingFiles bool
@@ -110,6 +113,7 @@ func TestTransition(t *testing.T) {
 			SymbolicLinkMode_SymbolicLinkModePortable,
 			[]*Entry{tF1},
 			nil,
+			true,
 			false,
 		},
 		{
@@ -123,6 +127,7 @@ func TestTransition(t *testing.T) {
 			SymbolicLinkMode_SymbolicLinkModePortable,
 			[]*Entry{tD1},
 			nil,
+			true,
 			false,
 		},
 		{
@@ -138,6 +143,7 @@ func TestTransition(t *testing.T) {
 			SymbolicLinkMode_SymbolicLinkModePortable,
 			[]*Entry{tDM},
 			nil,
+			true,
 			false,
 		},
 		{
@@ -153,6 +159,7 @@ func TestTransition(t *testing.T) {
 			SymbolicLinkMode_SymbolicLinkModePortable,
 			testingNWildcardEntries(uint(tDM.Count())),
 			nil,
+			true,
 			false,
 		},
 
@@ -168,6 +175,7 @@ func TestTransition(t *testing.T) {
 			SymbolicLinkMode_SymbolicLinkModePortable,
 			[]*Entry{nil},
 			nil,
+			true,
 			false,
 		},
 		{
@@ -181,6 +189,7 @@ func TestTransition(t *testing.T) {
 			SymbolicLinkMode_SymbolicLinkModePortable,
 			[]*Entry{nil},
 			nil,
+			true,
 			false,
 		},
 		{
@@ -196,6 +205,7 @@ func TestTransition(t *testing.T) {
 			SymbolicLinkMode_SymbolicLinkModePortable,
 			[]*Entry{nil},
 			nil,
+			true,
 			false,
 		},
 		{
@@ -211,6 +221,7 @@ func TestTransition(t *testing.T) {
 			SymbolicLinkMode_SymbolicLinkModePortable,
 			testingNWildcardEntries(uint(tDM.Count())),
 			nil,
+			true,
 			false,
 		},
 
@@ -226,6 +237,7 @@ func TestTransition(t *testing.T) {
 			SymbolicLinkMode_SymbolicLinkModePortable,
 			[]*Entry{tF2},
 			nil,
+			true,
 			false,
 		},
 		{
@@ -239,6 +251,7 @@ func TestTransition(t *testing.T) {
 			SymbolicLinkMode_SymbolicLinkModePortable,
 			[]*Entry{tF2},
 			nil,
+			true,
 			false,
 		},
 		{
@@ -254,6 +267,7 @@ func TestTransition(t *testing.T) {
 			SymbolicLinkMode_SymbolicLinkModePortable,
 			[]*Entry{executable(tF1)},
 			nil,
+			true,
 			false,
 		},
 		{
@@ -269,6 +283,7 @@ func TestTransition(t *testing.T) {
 			SymbolicLinkMode_SymbolicLinkModePortable,
 			[]*Entry{tF1},
 			nil,
+			true,
 			false,
 		},
 		{
@@ -291,6 +306,7 @@ func TestTransition(t *testing.T) {
 			[]*Entry{tF1},
 			[]*Problem{{Path: "file", Error: "*"}},
 			false,
+			false,
 		},
 
 		// Test traversal problems.
@@ -305,6 +321,7 @@ func TestTransition(t *testing.T) {
 			SymbolicLinkMode_SymbolicLinkModePortable,
 			[]*Entry{nil},
 			[]*Problem{{Path: "subpath", Error: "*"}},
+			false,
 			false,
 		},
 		{
@@ -327,6 +344,7 @@ func TestTransition(t *testing.T) {
 			[]*Entry{nil},
 			[]*Problem{{Path: "populated subdir/thing.txt", Error: "*"}},
 			false,
+			false,
 		},
 		{
 			"casing invalid",
@@ -340,6 +358,7 @@ func TestTransition(t *testing.T) {
 			[]*Entry{tF1},
 			[]*Problem{{Path: "FILE", Error: "*"}},
 			false,
+			false,
 		},
 		{
 			"parent casing invalid",
@@ -352,6 +371,7 @@ func TestTransition(t *testing.T) {
 			SymbolicLinkMode_SymbolicLinkModePortable,
 			[]*Entry{tF1},
 			[]*Problem{{Path: "SUBdir/file", Error: "*"}},
+			false,
 			false,
 		},
 
@@ -368,6 +388,7 @@ func TestTransition(t *testing.T) {
 			[]*Entry{nil},
 			[]*Problem{{Error: "*"}},
 			false,
+			false,
 		},
 		{
 			"invalid content type creation",
@@ -380,6 +401,7 @@ func TestTransition(t *testing.T) {
 			SymbolicLinkMode_SymbolicLinkModePortable,
 			[]*Entry{tD0},
 			[]*Problem{{Path: "child", Error: "*"}},
+			true,
 			false,
 		},
 		{
@@ -394,6 +416,7 @@ func TestTransition(t *testing.T) {
 			[]*Entry{nil},
 			[]*Problem{{Error: "*"}},
 			false,
+			false,
 		},
 		{
 			"root already exists on directory root creation",
@@ -406,6 +429,7 @@ func TestTransition(t *testing.T) {
 			SymbolicLinkMode_SymbolicLinkModePortable,
 			[]*Entry{nil},
 			[]*Problem{{Error: "*"}},
+			false,
 			false,
 		},
 		{
@@ -426,6 +450,7 @@ func TestTransition(t *testing.T) {
 			[]*Entry{nil},
 			[]*Problem{{Path: "link", Error: "*"}},
 			false,
+			false,
 		},
 
 		// Test removal problems.
@@ -441,6 +466,7 @@ func TestTransition(t *testing.T) {
 			[]*Entry{{Kind: -1}},
 			[]*Problem{{Error: "*"}},
 			false,
+			false,
 		},
 		{
 			"invalid content type removal",
@@ -453,6 +479,7 @@ func TestTransition(t *testing.T) {
 			SymbolicLinkMode_SymbolicLinkModePortable,
 			[]*Entry{nested("file", &Entry{Kind: -1})},
 			[]*Problem{{Path: "file", Error: "*"}},
+			false,
 			false,
 		},
 		{
@@ -471,6 +498,7 @@ func TestTransition(t *testing.T) {
 			SymbolicLinkMode_SymbolicLinkModePortable,
 			[]*Entry{tF1},
 			[]*Problem{{Error: "*"}},
+			false,
 			false,
 		},
 		{
@@ -516,6 +544,7 @@ func TestTransition(t *testing.T) {
 				{Path: "file link", Error: "*"},
 				{Path: "populated subdir", Error: "*"},
 			},
+			true,
 			false,
 		},
 		{
@@ -531,6 +560,7 @@ func TestTransition(t *testing.T) {
 			SymbolicLinkMode_SymbolicLinkModeIgnore,
 			[]*Entry{tSR},
 			[]*Problem{{Path: "file link", Error: "*"}},
+			false,
 			false,
 		},
 		{
@@ -554,6 +584,7 @@ func TestTransition(t *testing.T) {
 			[]*Entry{tSR},
 			[]*Problem{{Path: "file link", Error: "*"}},
 			false,
+			false,
 		},
 		{
 			"symbolic link removal with modified (to (invalid) absolute) symbolic link target",
@@ -576,6 +607,7 @@ func TestTransition(t *testing.T) {
 			[]*Entry{tSR},
 			[]*Problem{{Path: "file link", Error: "*"}},
 			false,
+			false,
 		},
 		{
 			"inaccessible directory removal",
@@ -597,6 +629,7 @@ func TestTransition(t *testing.T) {
 			[]*Entry{tD1},
 			[]*Problem{{Path: "populated subdir", Error: "*"}},
 			false,
+			false,
 		},
 
 		// Test file swapping problems.
@@ -617,6 +650,7 @@ func TestTransition(t *testing.T) {
 			[]*Entry{tF1},
 			[]*Problem{{Error: "*"}},
 			false,
+			false,
 		},
 
 		// Test with a cancelled context.
@@ -631,6 +665,7 @@ func TestTransition(t *testing.T) {
 			SymbolicLinkMode_SymbolicLinkModePortable,
 			[]*Entry{tD1},
 			[]*Problem{{Error: errTransitionCancelled.Error()}},
+			false,
 			false,
 		},
 
@@ -647,6 +682,7 @@ func TestTransition(t *testing.T) {
 			[]*Entry{tD0},
 			[]*Problem{{Path: "file", Error: "*"}},
 			true,
+			true,
 		},
 
 		// Test symbolic link creation problems.
@@ -662,6 +698,7 @@ func TestTransition(t *testing.T) {
 			[]*Entry{nil},
 			[]*Problem{{Path: "link", Error: "*"}},
 			false,
+			false,
 		},
 		{
 			"invalid absolute symbolic link",
@@ -674,6 +711,7 @@ func TestTransition(t *testing.T) {
 			SymbolicLinkMode_SymbolicLinkModePortable,
 			[]*Entry{nil},
 			[]*Problem{{Path: "link", Error: "*"}},
+			false,
 			false,
 		},
 	}
@@ -757,7 +795,7 @@ func TestTransition(t *testing.T) {
 				contentMap: test.transitionsContentMap,
 				hasher:     newTestingHasher(),
 			}
-			results, problems, missingFiles := Transition(
+			results, problems, anyChangePerformed, missingFiles := Transition(
 				test.context,
 				root,
 				test.transitions,
@@ -790,11 +828,18 @@ func TestTransition(t *testing.T) {
 				t.Errorf("%s: problems do not match expected on %s filesystem", test.description, filesystem.name)
 			}
 
+			// Check whether or not changes were expected.
+			if anyChangePerformed && !test.expectAnyChangePerformed {
+				t.Errorf("%s: changes performed unexpectedly with %s filesystem", test.description, filesystem.name)
+			} else if !anyChangePerformed && test.expectAnyChangePerformed {
+				t.Errorf("%s: expected changes with %s filesystem", test.description, filesystem.name)
+			}
+
 			// Check missing file status.
 			if missingFiles && !test.expectMissingFiles {
 				t.Errorf("%s: unexpectedly missing staged files with %s filesystem", test.description, filesystem.name)
 			} else if !missingFiles && test.expectMissingFiles {
-				t.Errorf("%s: unexpectedly not missing staged files with %s filesystem", test.description, filesystem.name)
+				t.Errorf("%s: expected missing staged files with %s filesystem", test.description, filesystem.name)
 			}
 
 			// Perform cleanup.

--- a/pkg/synchronization/endpoint/local/endpoint.go
+++ b/pkg/synchronization/endpoint/local/endpoint.go
@@ -44,6 +44,19 @@ const (
 	recursiveWatchingEventCoalescingWindow = 10 * time.Millisecond
 )
 
+// reifiedWatchMode describes a fully reified watch mode based on the watch mode
+// specified for the endpoint and the availability of modes on the system.
+type reifiedWatchMode uint8
+
+const (
+	// reifiedWatchModeDisabled indicates that watching has been disabled.
+	reifiedWatchModeDisabled reifiedWatchMode = iota
+	// reifiedWatchModeRecursive indicates that recursive watching is in use.
+	reifiedWatchModeRecursive
+	// reifiedWatchModePoll indicates poll-based watching is in use.
+	reifiedWatchModePoll
+)
+
 // endpoint provides a local, in-memory implementation of
 // synchronization.Endpoint for local files.
 type endpoint struct {
@@ -92,10 +105,9 @@ type endpoint struct {
 	// "portable" permission propagation. This field is static and thus safe for
 	// concurrent reads.
 	defaultOwnership *filesystem.OwnershipSpecification
-	// watchIsRecursive indicates that a watching Goroutine exists and that it
-	// is using native recursive watching. This field is static and thus safe
-	// for concurrent reads.
-	watchIsRecursive bool
+	// actualWatchMode indicates the actual watch mode being used. This field is
+	// static and thus safe for concurrent reads.
+	actualWatchMode reifiedWatchMode
 	// workerCancel cancels any background worker Goroutines for the endpoint.
 	// This field is static and safe for concurrent invocation.
 	workerCancel context.CancelFunc
@@ -120,9 +132,10 @@ type endpoint struct {
 	// the recursive watching Goroutine (if any) that it should try to
 	// re-establish watching. It is a non-buffered channel, with reads only
 	// occurring when the recursive watching Goroutine is waiting to retry watch
-	// establishment and writes only occurring in a non-blocking fashion. This
-	// field is static and never closed, and is thus safe for concurrent send
-	// operations.
+	// establishment and writes only occurring in a non-blocking fashion
+	// (meaning this is a best-effort signaling mechanism (with a fallback to a
+	// timer-based signal)). This field is static and never closed, and is thus
+	// safe for concurrent send operations.
 	recursiveWatchRetryEstablish chan struct{}
 	// recursiveWatchReenableAcceleration is a channel used to signal the
 	// recursive watching Goroutine (if any) that acceleration has been disabled
@@ -357,9 +370,22 @@ func NewEndpoint(
 		watchMode = version.DefaultWatchMode()
 	}
 
-	// Compute whether or not we're going to use native recursive watching.
-	watchIsRecursive := watchMode == synchronization.WatchMode_WatchModePortable &&
-		watching.RecursiveWatchingSupported
+	// Compute the reified watch mode. The structure of this logic should match
+	// that of the watching Goroutine startup below.
+	var actualWatchMode reifiedWatchMode
+	if watchMode == synchronization.WatchMode_WatchModePortable {
+		if watching.RecursiveWatchingSupported {
+			actualWatchMode = reifiedWatchModeRecursive
+		} else {
+			actualWatchMode = reifiedWatchModePoll
+		}
+	} else if watchMode == synchronization.WatchMode_WatchModeForcePoll {
+		actualWatchMode = reifiedWatchModePoll
+	} else if watchMode == synchronization.WatchMode_WatchModeNoWatch {
+		actualWatchMode = reifiedWatchModeDisabled
+	} else {
+		panic("unhandled watch mode")
+	}
 
 	// HACK: If non-default ownership or permissions have been set and the
 	// synchronization root is a volume mount point in a Mutagen sidecar
@@ -399,7 +425,7 @@ func NewEndpoint(
 		defaultFileMode:                    defaultFileMode,
 		defaultDirectoryMode:               defaultDirectoryMode,
 		defaultOwnership:                   defaultOwnership,
-		watchIsRecursive:                   watchIsRecursive,
+		actualWatchMode:                    actualWatchMode,
 		workerCancel:                       workerCancel,
 		saveCacheDone:                      saveCacheDone,
 		watchDone:                          watchDone,
@@ -430,6 +456,8 @@ func NewEndpoint(
 	}
 
 	// Start the appropriate watching mechanism and monitor for its completion.
+	// The structure of this logic should match that of the reified watch mode
+	// computation above.
 	if watchMode == synchronization.WatchMode_WatchModePortable {
 		if watching.RecursiveWatchingSupported {
 			go func() {
@@ -452,7 +480,6 @@ func NewEndpoint(
 			close(watchDone)
 		}()
 	} else if watchMode == synchronization.WatchMode_WatchModeNoWatch {
-		// Don't start any watcher.
 		close(watchDone)
 	} else {
 		panic("unhandled watch mode")
@@ -620,7 +647,9 @@ WatchEstablishment:
 
 		// Reset the scan timer (which won't be running) to fire immediately in
 		// our watch loop in order to try to enable accelerated scanning.
-		scanTimer.Reset(0)
+		if e.accelerationAllowed {
+			scanTimer.Reset(0)
+		}
 
 		// Loop and process events.
 	EventProcessing:
@@ -1093,9 +1122,12 @@ func (e *endpoint) Scan(ctx context.Context, _ *core.Entry, full bool) (*core.En
 	// recent) snapshot, so acceleration will still work.
 	//
 	// If we see any error while scanning, we just have to assume that it's due
-	// to concurrent modifications and suggest a retry.
+	// to concurrent modifications and suggest a retry. In the case of
+	// accelerated scanning with recursive watching, there's no need to disable
+	// acceleration on failure so long as the watch is still established (and if
+	// it's not, that will handled elsewhere).
 	if e.accelerateScan && !full {
-		if e.watchIsRecursive {
+		if e.actualWatchMode == reifiedWatchModeRecursive {
 			if err := e.scan(ctx, e.snapshot, e.recheckPaths); err != nil {
 				return nil, false, err, true
 			} else {
@@ -1109,6 +1141,9 @@ func (e *endpoint) Scan(ctx context.Context, _ *core.Entry, full bool) (*core.En
 	}
 
 	// Verify that we haven't exceeded the maximum entry count.
+	// TODO: Do we actually want to enforce this count in the scan operation so
+	// that we don't hold those entries in memory? Right now this is mostly
+	// concerned with avoiding transmission of the entries over the wire.
 	if e.lastScanEntryCount > e.maximumEntryCount {
 		return nil, false, errors.New("exceeded allowed entry count"), true
 	}
@@ -1310,7 +1345,7 @@ func (e *endpoint) Transition(ctx context.Context, transitions []*core.Change) (
 	}
 
 	// Perform the transition.
-	results, problems, stagerMissingFiles := core.Transition(
+	results, problems, transitionMadeChanges, stagerMissingFiles := core.Transition(
 		ctx,
 		e.root,
 		transitions,
@@ -1329,7 +1364,7 @@ func (e *endpoint) Transition(ctx context.Context, transitions []*core.Change) (
 	// immediately, because Transition likely created the synchronization root
 	// in that case. If the Goroutine already has a watch established, then this
 	// is a no-op.
-	if e.watchIsRecursive {
+	if e.actualWatchMode == reifiedWatchModeRecursive {
 		select {
 		case e.recursiveWatchRetryEstablish <- struct{}{}:
 		default:
@@ -1343,14 +1378,14 @@ func (e *endpoint) Transition(ctx context.Context, transitions []*core.Change) (
 	// events to be lost and a (partially or completely) pre-Transition
 	// baseline-based scan to be generated in the small window before the watch
 	// error is detected). Both of these "failure" modes can happen in normal
-	// operation (with externally generated events), but it is problematic in
-	// the case of Transition because returning a pre-Transition snapshot can
-	// lead to a feedback loop between endpoints (depending on the phase and
-	// mode of their watching Goroutines) where they essentially swap returned
-	// snapshots each time (one pre-Transition and one post-Transition) and
-	// changes are continually inverted and bounced back and forth between the
-	// endpoints. This isn't just hypothetical - it's quite easy to reproduce
-	// with poll-based watching and a large(ish) polling interval (e.g. a few
+	// operation (with externally generated events), but it is particularly
+	// problematic in the case of Transition because returning a pre-Transition
+	// snapshot can lead to a feedback loop between endpoints (depending on the
+	// phase and mode of their watching Goroutines) where they essentially swap
+	// returned snapshots each time (one pre-Transition and one post-Transition)
+	// and changes are continually inverted and bounced back and forth between
+	// the endpoints. This isn't just hypothetical - it's easy to reproduce with
+	// poll-based watching and a large(ish) polling interval (e.g. a few
 	// seconds). The reason we don't need to worry about scans being stale in
 	// normal operation is that there isn't a corresponding actor on the other
 	// endpoint that's returning snapshots with constantly inverted changes
@@ -1360,11 +1395,34 @@ func (e *endpoint) Transition(ctx context.Context, transitions []*core.Change) (
 	// scan, while for recursive watching we need to manually signal that it
 	// should attempt to re-enable accelated scanning.
 	e.accelerateScan = false
-	if e.watchIsRecursive {
+	if e.actualWatchMode == reifiedWatchModeRecursive {
 		select {
 		case e.recursiveWatchReenableAcceleration <- struct{}{}:
 		default:
 		}
+	}
+
+	// If we're using poll-based watching, then strobe the polling channel if
+	// Transition made any changes on disk. This is necessary to work around
+	// cases where some other mechanism rapidly (and fully) inverts changes, in
+	// which case the pre-Transition and post-Transition scans will look the
+	// same to the poll-based watching Goroutine and the inversion operation
+	// (which should be reported back to the controller) won't be caught.
+	//
+	// An example of this is when a new file is propagated but then removed by
+	// the user before the next poll-based scan. In this case, the polling scan
+	// looks the same before and after Transition, and no polling event will be
+	// generated if we don't do it here. It's important that we only do this if
+	// on-disk changes were actually applied, otherwise we'll drive a feedback
+	// loop when problems are encountered for changes that can never be fully
+	// applied.
+	//
+	// We don't do this if the watch is recursive (since any inversion changes
+	// will be captured by the watch or a poll triggered on watch
+	// re-establishment if necessary) or if watching is disabled (in which case
+	// this isn't the behavior we want).
+	if transitionMadeChanges && e.actualWatchMode == reifiedWatchModePoll {
+		e.strobePollEvents()
 	}
 
 	// Wipe the staging directory. We don't monitor for errors here, because we

--- a/pkg/synchronization/endpoint/local/endpoint.go
+++ b/pkg/synchronization/endpoint/local/endpoint.go
@@ -1299,12 +1299,12 @@ func (e *endpoint) Transition(ctx context.Context, transitions []*core.Change) (
 		// If the resulting entry count would be too high, then abort the
 		// transitioning operation, but return the error as a problem, not an
 		// error, since nobody is malfunctioning here.
-		results := make([]*core.Entry, len(transitions))
-		for t, transition := range transitions {
-			results[t] = transition.Old
-		}
-		problems := []*core.Problem{{Error: "transitioning would exceeded allowed entry count"}}
 		if e.maximumEntryCount < resultingEntryCount {
+			results := make([]*core.Entry, len(transitions))
+			for t, transition := range transitions {
+				results[t] = transition.Old
+			}
+			problems := []*core.Problem{{Error: "transitioning would exceeded allowed entry count"}}
 			return results, problems, false, nil
 		}
 	}


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

There was a bug (or limitation, at least) in the poll-based watching logic where an externally performed, full inversion of the operations applied by `Transition` could prevent a polling event from being generated if the inversion happened between polling scans.  This was most evident if a new file was propagated to a poll-based watching system and then immediately deleted by the user, but it could happen in more complex scenarios too, so long as the operations performed by `Transition` were fully inverted.  Nothing bad would happen, but the controller wouldn't be notified that a change had occurred (since the poll-based scans wouldn't see any change) until a sync cycle was triggered manually or by some other event.

To fix this, `Transition` itself will now trigger a polling event if (and only if) it modifies the filesystem and poll-based watching is being used.

This is separate from the reason that we disable accelerated scanning in `Transition`, though both are related to issues with stale scans.  In this case though, there was only a risk of delayed synchronization.

This PR lumps in a few comment, doc, and test changes as well that occurred in the process of fixing this bug.
