### PR TITLE
ci: increase timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
   linux:
     name: Linux
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -82,7 +82,7 @@ jobs:
   windows:
     name: Windows
     runs-on: windows-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -105,7 +105,7 @@ jobs:
     name: Sidecar (Non-release)
     runs-on: ubuntu-latest
     if: github.ref_type != 'tag'
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -132,7 +132,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref_type == 'tag'
     needs: [macos, linux, windows]
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

The switch from Windows Server 2019 to Windows Server 2022 as the default for `windows-latest` on GitHub Actions seems to have drastically increased CI times. This seems to be almost exclusively due to the `setup_docker.sh` script, which has jumped from an execution time of approximately 80 seconds to over 8 minutes. Hard to debug exactly why since they're using the Mirantis Container Runtime rather than stock Docker, but it could even just be down to slower network connectivity today. In any case, our timeouts might have been too aggressive, so this commit makes them a bit more conservative.
