### PR TITLE
Add link to MacOS GUI app

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ their workflows:
 - [**MutagenMon**](https://github.com/rualark/MutagenMon) is a Python-based GUI
   for monitoring Mutagen sessions. Thanks to
   [**@rualark**](https://github.com/rualark)!
+- [**mutagenmon**](https://github.com/andrewmed/mutagenmon) is an alternative
+  (Go-based) native GUI for Mac, for monitoring Mutagen sessions, provides apple
+  notarized builds.
 
 
 ## Unrelated projects


### PR DESCRIPTION
Hi
Welcome to add link to Mac OS GUI for Mutagen

I have added notarised builds https://github.com/andrewmed/mutagenmon/releases
(tested on different machines, runs without need to unlock in "Security" tab in system preferences)