### PR TITLE
sync: winfsnotify updates

### DIFF
--- a/pkg/filesystem/watching/internal/third_party/winfsnotify/winfsnotify.go
+++ b/pkg/filesystem/watching/internal/third_party/winfsnotify/winfsnotify.go
@@ -345,9 +345,6 @@ func (w *Watcher) deleteWatch(watch *watch) {
 	}
 }
 
-// From https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#short-vs-long-names
-const maxExtendedLengthPath = 32767
-
 // Must run within the I/O thread.
 func (w *Watcher) startRead(watch *watch) error {
 	if e := syscall.CancelIo(watch.ino.handle); e != nil {
@@ -454,8 +451,7 @@ func (w *Watcher) readEvents() {
 
 			// Point "raw" to the event in the buffer
 			raw := (*syscall.FileNotifyInformation)(unsafe.Pointer(&watch.buf[offset]))
-			buf := (*[maxExtendedLengthPath]uint16)(unsafe.Pointer(&raw.FileName))
-			name := syscall.UTF16ToString(buf[:raw.FileNameLength/2])
+			name := syscall.UTF16ToString(unsafe.Slice(&raw.FileName, raw.FileNameLength/2))
 			fullname := filepath.Join(watch.path, name)
 
 			var mask uint64

--- a/pkg/filesystem/watching/internal/third_party/winfsnotify/winfsnotify_test.go
+++ b/pkg/filesystem/watching/internal/third_party/winfsnotify/winfsnotify_test.go
@@ -49,22 +49,23 @@ package winfsnotify
 import (
 	"os"
 	"path/filepath"
-	"sync"
 	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
 )
 
-func expect(t *testing.T, eventstream <-chan *Event, name string, mask uint32) {
+func expect(t *testing.T, watcher *Watcher, name string, mask uint32) {
 	select {
-	case event := <-eventstream:
+	case event := <-watcher.Event:
 		if event == nil {
 			t.Fatal("nil event received")
 		}
 		if event.Name != name || event.Mask != mask {
 			t.Fatal("did not receive expected event")
 		}
+	case err := <-watcher.Error:
+		t.Fatal("received error:", err)
 	case <-time.After(1 * time.Second):
 		t.Fatal("timed out waiting for event")
 	}
@@ -97,7 +98,7 @@ func TestNotifyEvents(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating test file failed: %s", err)
 	}
-	expect(t, watcher.Event, testFile, FS_CREATE)
+	expect(t, watcher, testFile, FS_CREATE)
 
 	err = watcher.AddWatch(testFile, mask)
 	if err != nil {
@@ -110,24 +111,24 @@ func TestNotifyEvents(t *testing.T) {
 	if err = file.Close(); err != nil {
 		t.Fatalf("failed to close test file: %s", err)
 	}
-	expect(t, watcher.Event, testFile, FS_MODIFY)
-	expect(t, watcher.Event, testFile, FS_MODIFY)
+	expect(t, watcher, testFile, FS_MODIFY)
+	expect(t, watcher, testFile, FS_MODIFY)
 
 	if err = os.Rename(testFile, testFile2); err != nil {
 		t.Fatalf("failed to rename test file: %s", err)
 	}
-	expect(t, watcher.Event, testFile, FS_MOVED_FROM)
-	expect(t, watcher.Event, testFile2, FS_MOVED_TO)
-	expect(t, watcher.Event, testFile, FS_MOVE_SELF)
+	expect(t, watcher, testFile, FS_MOVED_FROM)
+	expect(t, watcher, testFile2, FS_MOVED_TO)
+	expect(t, watcher, testFile, FS_MOVE_SELF)
 
 	if err = os.RemoveAll(testDir); err != nil {
 		t.Fatalf("failed to remove test directory: %s", err)
 	}
-	expect(t, watcher.Event, testFile2, FS_DELETE_SELF)
-	expect(t, watcher.Event, testFile2, FS_IGNORED)
-	expect(t, watcher.Event, testFile2, FS_DELETE)
-	expect(t, watcher.Event, testDir, FS_DELETE_SELF)
-	expect(t, watcher.Event, testDir, FS_IGNORED)
+	expect(t, watcher, testFile2, FS_DELETE_SELF)
+	expect(t, watcher, testFile2, FS_IGNORED)
+	expect(t, watcher, testFile2, FS_DELETE)
+	expect(t, watcher, testDir, FS_DELETE_SELF)
+	expect(t, watcher, testDir, FS_IGNORED)
 
 	if err = watcher.Close(); err != nil {
 		t.Fatalf("failed to close watcher: %s", err)
@@ -183,17 +184,6 @@ func TestWatchLongPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewWatcher() failed: %s", err)
 	}
-
-	// Receive errors on the error channel on a separate goroutine
-	var wg sync.WaitGroup
-	wg.Add(1)
-	defer wg.Wait()
-	go func() {
-		defer wg.Done()
-		for err := range watcher.Error {
-			t.Fatalf("error received: %s", err)
-		}
-	}()
 	defer watcher.Close()
 
 	err = watcher.AddWatch(dir, FS_ALL_EVENTS)
@@ -205,5 +195,5 @@ func TestWatchLongPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("WriteFile failed: %s", err)
 	}
-	expect(t, watcher.Event, newFile, FS_CREATE)
+	expect(t, watcher, newFile, FS_CREATE)
 }

--- a/pkg/filesystem/watching/internal/third_party/winfsnotify/winfsnotify_test.go
+++ b/pkg/filesystem/watching/internal/third_party/winfsnotify/winfsnotify_test.go
@@ -161,7 +161,7 @@ func TestNotifyClose(t *testing.T) {
 }
 
 func TestWatchLongPath(t *testing.T) {
-	dir, err := ioutil.TempDir("", "watch-extended-path")
+	dir, err := os.MkdirTemp("", "watch-extended-path")
 	if err != nil {
 		t.Fatalf("TempDir failed: %s", err)
 	}
@@ -201,7 +201,7 @@ func TestWatchLongPath(t *testing.T) {
 		t.Fatalf("Watcher.Watch() failed: %s", err)
 	}
 	newFile := filepath.Join(path, "new-file")
-	err = ioutil.WriteFile(newFile, []byte("test"), 0644)
+	err = os.WriteFile(newFile, []byte("test"), 0644)
 	if err != nil {
 		t.Fatalf("WriteFile failed: %s", err)
 	}

--- a/pkg/filesystem/watching/internal/third_party/winfsnotify/winfsnotify_test.go
+++ b/pkg/filesystem/watching/internal/third_party/winfsnotify/winfsnotify_test.go
@@ -162,11 +162,8 @@ func TestNotifyClose(t *testing.T) {
 }
 
 func TestWatchLongPath(t *testing.T) {
-	dir, err := os.MkdirTemp("", "watch-extended-path")
-	if err != nil {
-		t.Fatalf("TempDir failed: %s", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
+
 	// Create a path longer than syscall.MAX_PATH*2
 	path := dir
 	for {
@@ -175,8 +172,7 @@ func TestWatchLongPath(t *testing.T) {
 		}
 		path = filepath.Join(path, "another-dir")
 	}
-	err = os.MkdirAll(path, 0755)
-	if err != nil {
+	if err := os.MkdirAll(path, 0755); err != nil {
 		t.Fatalf("MkdirAll(%s) failed: %s", path, err)
 	}
 


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This pull request makes some slight tweaks to the winsfsnotify package, adapting it to recent Go runtime and testing changes.  The changes are minimal for now, just enough to make some of the recent long-path fixes work with Go's runtime checks, but a more extensive overhaul (or perhaps minimal, Mutagen-focused rewrite) of this package is still warranted.

