### PR TITLE
use interface for Logger

### DIFF
--- a/cmd/mutagen-agent/synchronizer.go
+++ b/cmd/mutagen-agent/synchronizer.go
@@ -25,7 +25,7 @@ const (
 )
 
 // housekeepRegularly is the entry point for the housekeeping Goroutine.
-func housekeepRegularly(context context.Context, logger *logging.Logger) {
+func housekeepRegularly(context context.Context, logger logging.Logger) {
 	// Perform an initial housekeeping operation since the ticker won't fire
 	// straight away.
 	logger.Info("Performing initial housekeeping")

--- a/pkg/agent/dial.go
+++ b/pkg/agent/dial.go
@@ -32,7 +32,7 @@ const (
 // remote environment is cmd.exe-based and returns hints as to whether or not
 // installation should be attempted and whether or not the remote environment is
 // cmd.exe-based.
-func connect(logger *logging.Logger, transport Transport, mode, prompter string, cmdExe bool) (io.ReadWriteCloser, bool, bool, error) {
+func connect(logger logging.Logger, transport Transport, mode, prompter string, cmdExe bool) (io.ReadWriteCloser, bool, bool, error) {
 	// Compute the agent invocation command, relative to the user's home
 	// directory on the remote. Unless we have reason to assume that this is a
 	// cmd.exe environment, we construct a path using forward slashes. This will
@@ -176,7 +176,7 @@ func connect(logger *logging.Logger, transport Transport, mode, prompter string,
 
 // Dial connects to an agent-based endpoint using the specified transport,
 // connection mode, and prompter.
-func Dial(logger *logging.Logger, transport Transport, mode, prompter string) (io.ReadWriteCloser, error) {
+func Dial(logger logging.Logger, transport Transport, mode, prompter string) (io.ReadWriteCloser, error) {
 	// Validate that the mode is sane.
 	if !(mode == ModeSynchronizer || mode == ModeForwarder) {
 		panic("invalid agent dial mode")

--- a/pkg/agent/install.go
+++ b/pkg/agent/install.go
@@ -37,7 +37,7 @@ func Install() error {
 
 // install attempts to probe an endpoint and install the appropriate agent
 // binary over the specified transport.
-func install(logger *logging.Logger, transport Transport, prompter string) error {
+func install(logger logging.Logger, transport Transport, prompter string) error {
 	// Detect the target platform.
 	goos, goarch, posix, err := probe(transport, prompter)
 	if err != nil {

--- a/pkg/forwarding/connect.go
+++ b/pkg/forwarding/connect.go
@@ -16,7 +16,7 @@ type ProtocolHandler interface {
 	// endpoint using the specified parameters.
 	Connect(
 		ctx context.Context,
-		logger *logging.Logger,
+		logger logging.Logger,
 		url *urlpkg.URL,
 		prompter string,
 		session string,
@@ -33,7 +33,7 @@ var ProtocolHandlers = map[urlpkg.Protocol]ProtocolHandler{}
 // connect attempts to establish a connection to an endpoint.
 func connect(
 	ctx context.Context,
-	logger *logging.Logger,
+	logger logging.Logger,
 	url *urlpkg.URL,
 	prompter string,
 	session string,

--- a/pkg/forwarding/controller.go
+++ b/pkg/forwarding/controller.go
@@ -27,7 +27,7 @@ const (
 // controller manages and executes a single session.
 type controller struct {
 	// logger is the controller logger.
-	logger *logging.Logger
+	logger logging.Logger
 	// sessionPath is the path to the serialized session.
 	sessionPath string
 	// stateLock guards and tracks changes to session's Paused field and state.
@@ -73,7 +73,7 @@ type controller struct {
 // newSession creates a new session and corresponding controller.
 func newSession(
 	ctx context.Context,
-	logger *logging.Logger,
+	logger logging.Logger,
 	tracker *state.Tracker,
 	identifier string,
 	source, destination *url.URL,
@@ -208,7 +208,7 @@ func newSession(
 }
 
 // loadSession loads an existing session and creates a corresponding controller.
-func loadSession(logger *logging.Logger, tracker *state.Tracker, identifier string) (*controller, error) {
+func loadSession(logger logging.Logger, tracker *state.Tracker, identifier string) (*controller, error) {
 	// Compute the session path.
 	sessionPath, err := pathForSession(identifier)
 	if err != nil {

--- a/pkg/forwarding/endpoint/remote/server.go
+++ b/pkg/forwarding/endpoint/remote/server.go
@@ -51,7 +51,7 @@ func initializeEndpoint(request *InitializeForwardingRequest) (forwarding.Endpoi
 // It enforces that the provided stream is closed by the time this function
 // returns, regardless of failure. The provided stream must unblock read and
 // write operations when closed.
-func ServeEndpoint(logger *logging.Logger, stream io.ReadWriteCloser) error {
+func ServeEndpoint(logger logging.Logger, stream io.ReadWriteCloser) error {
 	// Adapt the connection to serve as a multiplexer carrier. This will also
 	// give us the buffering functionality we'll need for initialization.
 	carrier := multiplexing.NewCarrierFromStream(stream)

--- a/pkg/forwarding/manager.go
+++ b/pkg/forwarding/manager.go
@@ -18,7 +18,7 @@ import (
 // safe for concurrent usage, so it can be easily exported via an RPC interface.
 type Manager struct {
 	// logger is the underlying logger.
-	logger *logging.Logger
+	logger logging.Logger
 	// tracker tracks changes to session states.
 	tracker *state.Tracker
 	// sessionLock locks the sessions registry.
@@ -28,7 +28,7 @@ type Manager struct {
 }
 
 // NewManager creates a new Manager instance.
-func NewManager(logger *logging.Logger) (*Manager, error) {
+func NewManager(logger logging.Logger) (*Manager, error) {
 	// Create a tracker and corresponding lock to watch for state changes.
 	tracker := state.NewTracker()
 	sessionsLock := state.NewTrackingLock(tracker)

--- a/pkg/forwarding/protocols/docker/protocol.go
+++ b/pkg/forwarding/protocols/docker/protocol.go
@@ -31,7 +31,7 @@ type dialResult struct {
 // Connect connects to a Docker endpoint.
 func (p *protocolHandler) Connect(
 	ctx context.Context,
-	logger *logging.Logger,
+	logger logging.Logger,
 	url *urlpkg.URL,
 	prompter string,
 	session string,

--- a/pkg/forwarding/protocols/local/protocol.go
+++ b/pkg/forwarding/protocols/local/protocol.go
@@ -19,7 +19,7 @@ type protocolHandler struct{}
 // Connect implements forwarding.ProtocolHandler.Connect.
 func (p *protocolHandler) Connect(
 	_ context.Context,
-	logger *logging.Logger,
+	logger logging.Logger,
 	url *urlpkg.URL,
 	prompter string,
 	session string,

--- a/pkg/forwarding/protocols/ssh/protocol.go
+++ b/pkg/forwarding/protocols/ssh/protocol.go
@@ -31,7 +31,7 @@ type dialResult struct {
 // Connect connects to an SSH endpoint.
 func (p *protocolHandler) Connect(
 	ctx context.Context,
-	logger *logging.Logger,
+	logger logging.Logger,
 	url *urlpkg.URL,
 	prompter string,
 	session string,

--- a/pkg/integration/protocols/netpipe/forwarding.go
+++ b/pkg/integration/protocols/netpipe/forwarding.go
@@ -21,7 +21,7 @@ type forwardingProtocolHandler struct{}
 // endpoint client connected to the server via an in-memory connection.
 func (h *forwardingProtocolHandler) Connect(
 	_ context.Context,
-	logger *logging.Logger,
+	logger logging.Logger,
 	url *urlpkg.URL,
 	prompter string,
 	session string,

--- a/pkg/integration/protocols/netpipe/synchronization.go
+++ b/pkg/integration/protocols/netpipe/synchronization.go
@@ -44,7 +44,7 @@ func (w *waitingSynchronizationEndpoint) Shutdown() error {
 // endpoint client connected to the server via an in-memory connection.
 func (h *synchronizationProtocolHandler) Connect(
 	_ context.Context,
-	logger *logging.Logger,
+	logger logging.Logger,
 	url *urlpkg.URL,
 	prompter string,
 	session string,

--- a/pkg/synchronization/connect.go
+++ b/pkg/synchronization/connect.go
@@ -16,7 +16,7 @@ type ProtocolHandler interface {
 	// endpoint using the specified parameters.
 	Connect(
 		ctx context.Context,
-		logger *logging.Logger,
+		logger logging.Logger,
 		url *urlpkg.URL,
 		prompter string,
 		session string,
@@ -33,7 +33,7 @@ var ProtocolHandlers = map[urlpkg.Protocol]ProtocolHandler{}
 // connect attempts to establish a connection to an endpoint.
 func connect(
 	ctx context.Context,
-	logger *logging.Logger,
+	logger logging.Logger,
 	url *urlpkg.URL,
 	prompter string,
 	session string,

--- a/pkg/synchronization/controller.go
+++ b/pkg/synchronization/controller.go
@@ -32,7 +32,7 @@ const (
 // controller manages and executes a single session.
 type controller struct {
 	// logger is the controller logger.
-	logger *logging.Logger
+	logger logging.Logger
 	// sessionPath is the path to the serialized session.
 	sessionPath string
 	// archivePath is the path to the serialized archive.
@@ -94,7 +94,7 @@ type controller struct {
 // newSession creates a new session and corresponding controller.
 func newSession(
 	ctx context.Context,
-	logger *logging.Logger,
+	logger logging.Logger,
 	tracker *state.Tracker,
 	identifier string,
 	alpha, beta *url.URL,
@@ -240,7 +240,7 @@ func newSession(
 }
 
 // loadSession loads an existing session and creates a corresponding controller.
-func loadSession(logger *logging.Logger, tracker *state.Tracker, identifier string) (*controller, error) {
+func loadSession(logger logging.Logger, tracker *state.Tracker, identifier string) (*controller, error) {
 	// Compute session and archive paths.
 	sessionPath, err := pathForSession(identifier)
 	if err != nil {

--- a/pkg/synchronization/endpoint/local/endpoint.go
+++ b/pkg/synchronization/endpoint/local/endpoint.go
@@ -63,7 +63,7 @@ type endpoint struct {
 	// logger is the endpoint's underlying logger. This field is static and thus
 	// safe for concurrent usage (since the logger itself is safe for concurrent
 	// usage).
-	logger *logging.Logger
+	logger logging.Logger
 	// root is the synchronization root for the endpoint. This field is static
 	// and thus safe for concurrent reads.
 	root string
@@ -200,7 +200,7 @@ type endpoint struct {
 // NewEndpoint creates a new local endpoint instance using the specified session
 // metadata and options.
 func NewEndpoint(
-	logger *logging.Logger,
+	logger logging.Logger,
 	root string,
 	sessionIdentifier string,
 	version synchronization.Version,

--- a/pkg/synchronization/endpoint/remote/server.go
+++ b/pkg/synchronization/endpoint/remote/server.go
@@ -34,7 +34,7 @@ type endpointServer struct {
 // It enforces that the provided stream is closed by the time this function
 // returns, regardless of failure. The provided stream must unblock read and
 // write operations when closed.
-func ServeEndpoint(logger *logging.Logger, stream io.ReadWriteCloser) error {
+func ServeEndpoint(logger logging.Logger, stream io.ReadWriteCloser) error {
 	// Defer closure of the stream.
 	defer stream.Close()
 

--- a/pkg/synchronization/manager.go
+++ b/pkg/synchronization/manager.go
@@ -35,7 +35,7 @@ const (
 // interface.
 type Manager struct {
 	// logger is the underlying logger.
-	logger *logging.Logger
+	logger logging.Logger
 	// tracker tracks changes to session states.
 	tracker *state.Tracker
 	// sessionLock locks the sessions registry.
@@ -45,7 +45,7 @@ type Manager struct {
 }
 
 // NewManager creates a new Manager instance.
-func NewManager(logger *logging.Logger) (*Manager, error) {
+func NewManager(logger logging.Logger) (*Manager, error) {
 	// Create a tracker and corresponding lock to watch for state changes.
 	tracker := state.NewTracker()
 	sessionsLock := state.NewTrackingLock(tracker)

--- a/pkg/synchronization/protocols/docker/protocol.go
+++ b/pkg/synchronization/protocols/docker/protocol.go
@@ -30,7 +30,7 @@ type dialResult struct {
 // Connect connects to a Docker endpoint.
 func (h *protocolHandler) Connect(
 	ctx context.Context,
-	logger *logging.Logger,
+	logger logging.Logger,
 	url *urlpkg.URL,
 	prompter string,
 	session string,

--- a/pkg/synchronization/protocols/local/protocol.go
+++ b/pkg/synchronization/protocols/local/protocol.go
@@ -18,7 +18,7 @@ type protocolHandler struct{}
 // Connect connects to a local endpoint.
 func (h *protocolHandler) Connect(
 	_ context.Context,
-	logger *logging.Logger,
+	logger logging.Logger,
 	url *urlpkg.URL,
 	prompter string,
 	session string,

--- a/pkg/synchronization/protocols/ssh/protocol.go
+++ b/pkg/synchronization/protocols/ssh/protocol.go
@@ -30,7 +30,7 @@ type dialResult struct {
 // Connect connects to an SSH endpoint.
 func (h *protocolHandler) Connect(
 	ctx context.Context,
-	logger *logging.Logger,
+	logger logging.Logger,
 	url *urlpkg.URL,
 	prompter string,
 	session string,


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This allows for custom logging implementations instead of requiring
usage of the global logger from the `log` package.

**Any other notes for the review process?**

I have set the Logger interface to match exactly what the old `*logging.Logger` implementation had.  There are several functions that are not actually used currently in the codebase, for example, none of the format loggers (ie `Debugf`) are currently in use.