### PR TITLE
sync: add various scan optimizations

### DIFF
--- a/pkg/filesystem/directory_posix.go
+++ b/pkg/filesystem/directory_posix.go
@@ -233,7 +233,7 @@ func (d *Directory) open(name string, wantDirectory bool) (int, error) {
 
 	// Open the file for reading while avoiding symbolic link traversal. If a
 	// directory has been requested, then enforce its type here.
-	flags := unix.O_RDONLY | unix.O_NOFOLLOW | unix.O_CLOEXEC
+	flags := unix.O_RDONLY | unix.O_NOFOLLOW | unix.O_CLOEXEC | extraOpenFlags
 	if wantDirectory {
 		flags |= unix.O_DIRECTORY
 	}

--- a/pkg/filesystem/flags_linux.go
+++ b/pkg/filesystem/flags_linux.go
@@ -1,0 +1,8 @@
+package filesystem
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// extraOpenFlags specifies platform specific flags to include in open calls.
+const extraOpenFlags = unix.O_LARGEFILE

--- a/pkg/filesystem/flags_posix.go
+++ b/pkg/filesystem/flags_posix.go
@@ -1,0 +1,6 @@
+//go:build !linux && !windows
+
+package filesystem
+
+// extraOpenFlags specifies platform specific flags to include in open calls.
+const extraOpenFlags = 0

--- a/pkg/filesystem/open_posix.go
+++ b/pkg/filesystem/open_posix.go
@@ -46,7 +46,7 @@ func Open(path string, allowSymbolicLinkLeaf bool) (io.Closer, *Metadata, error)
 	// readlink and its ilk. Since ELOOP still sort of makes sense (we've
 	// encountered too many symbolic links at the path leaf), we return it
 	// unmodified.
-	flags := unix.O_RDONLY | unix.O_NOFOLLOW | unix.O_CLOEXEC
+	flags := unix.O_RDONLY | unix.O_NOFOLLOW | unix.O_CLOEXEC | extraOpenFlags
 	if allowSymbolicLinkLeaf {
 		flags &^= unix.O_NOFOLLOW
 	}

--- a/pkg/synchronization/core/diff.go
+++ b/pkg/synchronization/core/diff.go
@@ -18,11 +18,19 @@ func (d *differ) diff(path string, base, target *Entry) {
 		return
 	}
 
-	// Otherwise check contents for differences.
+	// Extract contents.
 	baseContents := base.GetContents()
 	targetContents := target.GetContents()
+
+	// Compute the prefix to add to content names to compute their paths.
+	var contentPathPrefix string
+	if path != "" && (len(baseContents) > 0 || len(targetContents) > 0) {
+		contentPathPrefix = path + "/"
+	}
+
+	// The nodes were equal at this path, so check their contents.
 	for name := range nameUnion(baseContents, targetContents) {
-		d.diff(pathJoin(path, name), baseContents[name], targetContents[name])
+		d.diff(contentPathPrefix+name, baseContents[name], targetContents[name])
 	}
 }
 

--- a/pkg/synchronization/core/entry.go
+++ b/pkg/synchronization/core/entry.go
@@ -142,13 +142,19 @@ func (e *Entry) walk(path string, visitor entryVisitor, reverse bool) {
 		visitor(path, e)
 	}
 
+	// Compute the prefix to add to content names to compute their paths.
+	var contentPathPrefix string
+	if path != "" && len(e.Contents) > 0 {
+		contentPathPrefix = path + "/"
+	}
+
 	// If this entry is non-nil, then visit any child entries. We don't bother
 	// checking if the entry is a directory since this is an internal method and
 	// the caller is responsible for enforcing entry invariants (meaning that
 	// only directories will have child entries).
 	if e != nil {
 		for name, child := range e.Contents {
-			child.walk(pathJoin(path, name), visitor, reverse)
+			child.walk(contentPathPrefix+name, visitor, reverse)
 		}
 	}
 

--- a/pkg/synchronization/core/path.go
+++ b/pkg/synchronization/core/path.go
@@ -4,26 +4,6 @@ import (
 	"strings"
 )
 
-// pathJoin is a fast alternative to path.Join designed specifically for
-// root-relative synchronization paths. It avoids the unnecessary path cleaning
-// overhead incurred by path.Join. The provided leaf name must be non-empty,
-// otherwise this function will panic.
-func pathJoin(base, leaf string) string {
-	// Disalllow empty leaf names.
-	if leaf == "" {
-		panic("empty leaf name")
-	}
-
-	// When joining a path to the synchronization root, we don't want to
-	// concatenate.
-	if base == "" {
-		return leaf
-	}
-
-	// Concatenate the paths.
-	return base + "/" + leaf
-}
-
 // pathDir is a fast alternative to path.Dir designed specifically for
 // root-relative synchronization paths. It avoids the unnecessary path cleaning
 // overhead incurred by path.Dir. Note that, unlike path.Dir, this function

--- a/pkg/synchronization/core/path_test.go
+++ b/pkg/synchronization/core/path_test.go
@@ -4,55 +4,6 @@ import (
 	"testing"
 )
 
-// pathJoinPanicFree is a wrapper around pathJoin that allows the caller to
-// track panics.
-func pathJoinPanicFree(base, leaf string, panicked *bool) string {
-	// Track panics.
-	defer func() {
-		if recover() != nil {
-			*panicked = true
-		}
-	}()
-
-	// Invoke pathJoin.
-	return pathJoin(base, leaf)
-}
-
-// TestPathJoin verifies that pathJoin behaves correctly in a number of test
-// cases.
-func TestPathJoin(t *testing.T) {
-	// Set up test cases.
-	testCases := []struct {
-		base        string
-		leaf        string
-		expected    string
-		expectPanic bool
-	}{
-		{"", "", "", true},
-		{"a", "", "", true},
-		{"", "a", "a", false},
-		{"", "a/b", "a/b", false},
-		{"a", "b", "a/b", false},
-		{"a/b", "c/d", "a/b/c/d", false},
-	}
-
-	// Process test cases.
-	for _, testCase := range testCases {
-		// Compute the result and track panics.
-		var panicked bool
-		if result := pathJoinPanicFree(testCase.base, testCase.leaf, &panicked); result != testCase.expected {
-			t.Error("pathJoin result did not match expected:", result, "!=", testCase.expected)
-		}
-
-		// Check panic behavior.
-		if panicked && !testCase.expectPanic {
-			t.Error("pathJoin panicked unexpectedly")
-		} else if !panicked && testCase.expectPanic {
-			t.Error("pathJoin did not panic as expected")
-		}
-	}
-}
-
 // pathDirPanicFree is a wrapper around pathDir that tracks panics.
 func pathDirPanicFree(path string, panicked *bool) string {
 	// Track panics.

--- a/pkg/synchronization/core/reconcile.go
+++ b/pkg/synchronization/core/reconcile.go
@@ -108,10 +108,16 @@ func (r *reconciler) reconcile(path string, ancestor, alpha, beta *Entry) {
 			ancestorContents = nil
 		}
 
+		// Compute the prefix to add to content names to compute their paths.
+		var contentPathPrefix string
+		if path != "" && (len(ancestorContents) > 0 || len(alphaContents) > 0 || len(betaContents) > 0) {
+			contentPathPrefix = path + "/"
+		}
+
 		// Recursively handle contents.
 		for name := range nameUnion(ancestorContents, alphaContents, betaContents) {
 			r.reconcile(
-				pathJoin(path, name),
+				contentPathPrefix+name,
 				ancestorContents[name],
 				alphaContents[name],
 				betaContents[name],

--- a/pkg/synchronization/core/scan.go
+++ b/pkg/synchronization/core/scan.go
@@ -346,6 +346,12 @@ func (s *scanner) directory(
 	// advantageous, because it gives us some opportunity to detect concurrent
 	// filesystem modifications.
 
+	// Compute the prefix to add to content names to compute their paths.
+	var contentPathPrefix string
+	if path != "" && len(directoryContents) > 0 {
+		contentPathPrefix = path + "/"
+	}
+
 	// Compute entries.
 	contents := make(map[string]*Entry, len(directoryContents))
 	for _, contentMetadata := range directoryContents {
@@ -372,7 +378,7 @@ func (s *scanner) directory(
 		}
 
 		// Compute the content path.
-		contentPath := pathJoin(path, contentName)
+		contentPath := contentPathPrefix + contentName
 
 		// Compute the kind for this content, recording an untracked entry if
 		// the content type isn't supported.

--- a/pkg/synchronization/core/stage.go
+++ b/pkg/synchronization/core/stage.go
@@ -19,8 +19,15 @@ func (f *stagingPathFinder) find(path string, entry *Entry) {
 	if entry == nil {
 		return
 	} else if entry.Kind == EntryKind_Directory {
+		// Compute the prefix to add to content names to compute their paths.
+		var contentPathPrefix string
+		if path != "" && len(entry.Contents) > 0 {
+			contentPathPrefix = path + "/"
+		}
+
+		// Process contents.
 		for name, entry := range entry.Contents {
-			f.find(pathJoin(path, name), entry)
+			f.find(contentPathPrefix+name, entry)
 		}
 	} else if entry.Kind == EntryKind_File {
 		f.paths = append(f.paths, path)

--- a/pkg/synchronization/core/transition.go
+++ b/pkg/synchronization/core/transition.go
@@ -383,6 +383,12 @@ func (t *transitioner) removeDirectory(parent *filesystem.Directory, name, path 
 	// APIs. The worst case fallout from this race is that directory removal
 	// will fail due to modifications that occur in this window.
 
+	// Compute the prefix to add to content names to compute their paths.
+	var contentPathPrefix string
+	if path != "" && len(contents) > 0 {
+		contentPathPrefix = path + "/"
+	}
+
 	// Loop through contents and remove them. We use the on-disk content listing
 	// to ensure that what we're removing has the proper case. If we were to
 	// just pass the OS whatever exists in our content map and the filesystem
@@ -409,7 +415,7 @@ ContentLoop:
 		}
 
 		// Compute the content path.
-		contentPath := pathJoin(path, contentName)
+		contentPath := contentPathPrefix + contentName
 
 		// Grab the corresponding entry. If we don't know anything about this
 		// entry, then mark that as a problem and ignore for now.
@@ -806,6 +812,12 @@ func (t *transitioner) createDirectory(parent *filesystem.Directory, name, path 
 		}
 	}
 
+	// Compute the prefix to add to content names to compute their paths.
+	var contentPathPrefix string
+	if path != "" && len(target.Contents) > 0 {
+		contentPathPrefix = path + "/"
+	}
+
 	// Attempt to create the target contents. We monitor for cancellation during
 	// this creation since it can block for a significant period of time.
 ContentLoop:
@@ -819,7 +831,7 @@ ContentLoop:
 		}
 
 		// Compute the content path.
-		contentPath := pathJoin(path, name)
+		contentPath := contentPathPrefix + name
 
 		// Handle content creation based on type.
 		if entry.Kind == EntryKind_Directory {


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This commit adds assorted performance optimizations to the filesystem scanning infrastructure.  It also fixes support for files > 4 GB in size on 32-bit Linux systems.

**Any other notes for the review process?**

I think we're reaching the edge of what we can accomplish in Go in terms of scan performance.  Right now, I see a ~25% overhead vs. a comparable `git status` operation for warm scans on the Linux source tree.  Unfortunately, there isn't any more obvious, low-hanging fruit in terms of optimizations in scan, and our CPU profiling seems to indicate that we're syscall-limited.  These numbers and considerations also hold true for cold scans.

On the bright side, that also indicates that scan performance will essentially improve "for free" as the Go runtime's system call overhead is reduced.

It's also worth remembering that most systems now use accelerated scanning, which doesn't need to perform full warm or cold rescans anyway.