### PR TITLE
deps: update additional dependencies and code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,9 +17,9 @@ require (
 	github.com/mutagen-io/gopass v0.0.0-20170602182606-9a121bec1ae7
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.5
-	golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce // indirect
-	golang.org/x/net v0.0.0-20220325170049-de3da57026de
-	golang.org/x/sys v0.0.0-20220330033206-e17cdc41300f
+	golang.org/x/crypto v0.0.0-20220331220935-ae2d96664a29 // indirect
+	golang.org/x/net v0.0.0-20220403103023-749bd193bc2b
+	golang.org/x/sys v0.0.0-20220403205710-6acee93ad0eb
 	golang.org/x/text v0.3.7
 	google.golang.org/grpc v1.45.0
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/mutagen-io/gopass v0.0.0-20170602182606-9a121bec1ae7
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.5
-	golang.org/x/crypto v0.0.0-20220331220935-ae2d96664a29 // indirect
 	golang.org/x/net v0.0.0-20220403103023-749bd193bc2b
 	golang.org/x/sys v0.0.0-20220403205710-6acee93ad0eb
 	golang.org/x/text v0.3.7
@@ -33,6 +32,7 @@ require (
 	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
+	golang.org/x/crypto v0.0.0-20220331220935-ae2d96664a29 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	google.golang.org/genproto v0.0.0-20220329172620-7be39ac1afc7 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce h1:Roh6XWxHFKrPgC/EQhVubSAGQ6Ozk6IdxHSzt1mR0EI=
-golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20220331220935-ae2d96664a29 h1:tkVvjkPTB7pnW3jnid7kNyAMPVWllTNOf/qKDze4p9o=
+golang.org/x/crypto v0.0.0-20220331220935-ae2d96664a29/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
@@ -185,8 +185,8 @@ golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210224082022-3d97a244fca7/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
-golang.org/x/net v0.0.0-20220325170049-de3da57026de h1:pZB1TWnKi+o4bENlbzAgLrEbY4RMYmUIRobMcSmfeYc=
-golang.org/x/net v0.0.0-20220325170049-de3da57026de/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
+golang.org/x/net v0.0.0-20220403103023-749bd193bc2b h1:vI32FkLJNAWtGD4BwkThwEy6XS7ZLLMHkSkYfF8M0W0=
+golang.org/x/net v0.0.0-20220403103023-749bd193bc2b/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -213,8 +213,8 @@ golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220330033206-e17cdc41300f h1:rlezHXNlxYWvBCzNses9Dlc7nGFaNMJeqLolcmQSSZY=
-golang.org/x/sys v0.0.0-20220330033206-e17cdc41300f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220403205710-6acee93ad0eb h1:PVGECzEo9Y3uOidtkHGdd347NjLtITfJFO9BxFpmRoo=
+golang.org/x/sys v0.0.0-20220403205710-6acee93ad0eb/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/pkg/encoding/yaml.go
+++ b/pkg/encoding/yaml.go
@@ -6,7 +6,7 @@ import (
 
 // LoadAndUnmarshalYAML loads data from the specified path and decodes it into
 // the specified structure.
-func LoadAndUnmarshalYAML(path string, value interface{}) error {
+func LoadAndUnmarshalYAML(path string, value any) error {
 	return LoadAndUnmarshal(path, func(data []byte) error {
 		return yaml.UnmarshalStrict(data, value)
 	})

--- a/pkg/filesystem/watching/internal/third_party/notify/event.go
+++ b/pkg/filesystem/watching/internal/third_party/notify/event.go
@@ -139,9 +139,9 @@ func (e Event) String() string {
 //
 //    https://msdn.microsoft.com/en-us/library/windows/desktop/aa365465%28v=vs.85%29.aspx
 type EventInfo interface {
-	Event() Event     // event value for the filesystem action
-	Path() string     // real path of the file or directory
-	Sys() interface{} // underlying data source (can return nil)
+	Event() Event // event value for the filesystem action
+	Path() string // real path of the file or directory
+	Sys() any     // underlying data source (can return nil)
 }
 
 type isDirer interface {

--- a/pkg/filesystem/watching/internal/third_party/notify/event_inotify.go
+++ b/pkg/filesystem/watching/internal/third_party/notify/event_inotify.go
@@ -102,5 +102,5 @@ type event struct {
 
 func (e *event) Event() Event         { return e.event }
 func (e *event) Path() string         { return e.path }
-func (e *event) Sys() interface{}     { return &e.sys }
+func (e *event) Sys() any             { return &e.sys }
 func (e *event) isDir() (bool, error) { return e.sys.Mask&unix.IN_ISDIR != 0, nil }

--- a/pkg/filesystem/watching/watch_non_recursive_linux.go
+++ b/pkg/filesystem/watching/watch_non_recursive_linux.go
@@ -66,7 +66,7 @@ func NewNonRecursiveWatcher(filter Filter) (NonRecursiveWatcher, error) {
 	}
 
 	// Set the eviction handler.
-	watcher.evictor.OnEvicted = func(key lru.Key, _ interface{}) {
+	watcher.evictor.OnEvicted = func(key lru.Key, _ any) {
 		if path, ok := key.(string); !ok {
 			panic("invalid key type in watch path cache")
 		} else {

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -53,70 +53,70 @@ func (l *Logger) output(level, line string) {
 }
 
 // println provides logging with formatting semantics equivalent to fmt.Println.
-func (l *Logger) println(level Level, v ...interface{}) {
+func (l *Logger) println(level Level, v ...any) {
 	if l != nil && currentLevel >= level {
 		l.output(level.String(), fmt.Sprintln(v...))
 	}
 }
 
 // printf provides logging with formatting semantics equivalent to fmt.Printf.
-func (l *Logger) printf(level Level, format string, v ...interface{}) {
+func (l *Logger) printf(level Level, format string, v ...any) {
 	if l != nil && currentLevel >= level {
 		l.output(level.String(), fmt.Sprintf(format, v...))
 	}
 }
 
 // Error logs errors with formatting semantics equivalent to fmt.Println.
-func (l *Logger) Error(v ...interface{}) {
+func (l *Logger) Error(v ...any) {
 	l.println(LevelError, v...)
 }
 
 // Errorf logs errors with formatting semantics equivalent to fmt.Printf.
-func (l *Logger) Errorf(format string, v ...interface{}) {
+func (l *Logger) Errorf(format string, v ...any) {
 	l.printf(LevelError, format, v...)
 }
 
 // Warning logs warnings with formatting semantics equivalent to fmt.Println.
-func (l *Logger) Warning(v ...interface{}) {
+func (l *Logger) Warning(v ...any) {
 	l.println(LevelWarning, v...)
 }
 
 // Warningf logs warnings with formatting semantics equivalent to fmt.Printf.
-func (l *Logger) Warningf(format string, v ...interface{}) {
+func (l *Logger) Warningf(format string, v ...any) {
 	l.printf(LevelWarning, format, v...)
 }
 
 // Info logs information with formatting semantics equivalent to fmt.Println.
-func (l *Logger) Info(v ...interface{}) {
+func (l *Logger) Info(v ...any) {
 	l.println(LevelInfo, v...)
 }
 
 // Infof logs information with formatting semantics equivalent to fmt.Printf.
-func (l *Logger) Infof(format string, v ...interface{}) {
+func (l *Logger) Infof(format string, v ...any) {
 	l.printf(LevelInfo, format, v...)
 }
 
 // Debug logs debug information with formatting semantics equivalent to
 // fmt.Println.
-func (l *Logger) Debug(v ...interface{}) {
+func (l *Logger) Debug(v ...any) {
 	l.println(LevelDebug, v...)
 }
 
 // Debugf logs debug information with formatting semantics equivalent to
 // fmt.Printf.
-func (l *Logger) Debugf(format string, v ...interface{}) {
+func (l *Logger) Debugf(format string, v ...any) {
 	l.printf(LevelDebug, format, v...)
 }
 
 // Trace logs tracing information with formatting semantics equivalent to
 // fmt.Println.
-func (l *Logger) Trace(v ...interface{}) {
+func (l *Logger) Trace(v ...any) {
 	l.println(LevelTrace, v...)
 }
 
 // Tracef logs tracing information with formatting semantics equivalent to
 // fmt.Printf.
-func (l *Logger) Tracef(format string, v ...interface{}) {
+func (l *Logger) Tracef(format string, v ...any) {
 	l.printf(LevelTrace, format, v...)
 }
 

--- a/pkg/mutagen/licenses.go
+++ b/pkg/mutagen/licenses.go
@@ -4,7 +4,7 @@ package mutagen
 // dependencies.
 const Licenses = `Mutagen
 
-Copyright (c) 2016 - present Mutagen IO, Inc.
+Copyright (c) 2016-present Mutagen IO, Inc.
 
 Licensed under the terms of the MIT License. A copy of this license can be found
 later in this text or online at https://opensource.org/licenses/MIT.

--- a/pkg/mutagen/licenses_sspl.go
+++ b/pkg/mutagen/licenses_sspl.go
@@ -7,7 +7,7 @@ package mutagen
 const mutagenSSPLEnhancementsHeader = `
 Mutagen SSPL-Licensed Enhancements
 
-Copyright (c) 2020 - present Mutagen IO, Inc.
+Copyright (c) 2020-present Mutagen IO, Inc.
 
 This executable contains Mutagen enhancements licensed under the terms of the
 Server Side Public License, version 1, as published by MongoDB, Inc. A copy of

--- a/pkg/project/configuration.go
+++ b/pkg/project/configuration.go
@@ -59,7 +59,7 @@ func (b FlushOnCreateBehavior) FlushOnCreate() bool {
 }
 
 // UnmarshalYAML implements Unmarshaler.UnmarshalYAML.
-func (b *FlushOnCreateBehavior) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (b *FlushOnCreateBehavior) UnmarshalYAML(unmarshal func(any) error) error {
 	// Call the underlying unmarshaling function.
 	var flush bool
 	if err := unmarshal(&flush); err != nil {


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This commit updates golang.org/x dependencies, updates `interface{}` types to `any` for Go 1.18, and makes slight formatting tweaks to license information.
