### PR TITLE
ci: allow non-signed SHA256SUMS generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,13 +50,14 @@ jobs:
           MACOS_NOTARIZE_APPLE_ID: ${{ secrets.MACOS_NOTARIZE_APPLE_ID }}
           MACOS_NOTARIZE_APP_SPECIFIC_PASSWORD: ${{ secrets.MACOS_NOTARIZE_APP_SPECIFIC_PASSWORD }}
           MACOS_NOTARIZE_TEAM_ID: ${{ secrets.MACOS_NOTARIZE_TEAM_ID }}
+      - run: scripts/ci/sha256sum.sh
       - uses: crazy-max/ghaction-import-gpg@v3
         id: import_gpg
         if: github.ref_type == 'tag'
         with:
           gpg-private-key: ${{ secrets.GPG_SIGNING_KEY }}
           passphrase: ${{ secrets.GPG_SIGNING_KEY_PASSWORD }}
-      - run: scripts/ci/sha256sum.sh
+      - run: scripts/ci/sha256sign.sh
         if: github.ref_type == 'tag'
         env:
           SHA256_GPG_SIGNING_IDENTITY: ${{ steps.import_gpg.outputs.email }}

--- a/scripts/ci/sha256sign.sh
+++ b/scripts/ci/sha256sign.sh
@@ -6,8 +6,11 @@ set -e
 # Move to the release directory.
 pushd build/release > /dev/null
 
-# Compute SHA256 digests.
-sha256sum mutagen_* > SHA256SUMS
+# Sign the SHA256 digests file.
+gpg --detach-sign --armor \
+    --default-key "${SHA256_GPG_SIGNING_IDENTITY}" \
+    --output SHA256SUMS.gpg \
+    SHA256SUMS
 
 # Leave the release directory.
 popd > /dev/null


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

Previously, we completely disabled SHA256SUMS in cases where the GPG signing key wasn't available (usually pull requests from third-party repositories), but we can just split up the SHA256 computation step into two parts, that way we can still perform SHA256 digests for test builds, they just won't be signed.
