### PR TITLE
all: prepare for v0.14.x

### DIFF
--- a/cmd/mutagen-sidecar/main.go
+++ b/cmd/mutagen-sidecar/main.go
@@ -28,7 +28,7 @@ func rootMain(command *cobra.Command, _ []string) error {
 var rootCommand = &cobra.Command{
 	Use:          "mutagen-sidecar",
 	Version:      mutagen.Version,
-	Short:        "Sidecar entry point for creating and controlling Mutagen sessions",
+	Short:        "Entry point for sidecar containers hosting Mutagen sessions",
 	RunE:         rootMain,
 	SilenceUsage: true,
 }

--- a/cmd/mutagen/daemon/run.go
+++ b/cmd/mutagen/daemon/run.go
@@ -120,10 +120,13 @@ func runMain(_ *cobra.Command, _ []string) error {
 	// server. We treat termination via the daemon service as a non-error.
 	select {
 	case sig := <-signalTermination:
+		logger.Info("Terminating due to signal:", sig)
 		return fmt.Errorf("terminated by signal: %s", sig)
 	case <-daemonServer.Termination:
+		logger.Info("Daemon termination requested")
 		return nil
 	case err = <-serverErrors:
+		logger.Error("Daemon server failure:", err)
 		return fmt.Errorf("daemon server termination: %w", err)
 	}
 }

--- a/cmd/mutagen/sync/list.go
+++ b/cmd/mutagen/sync/list.go
@@ -110,9 +110,8 @@ func formatEntry(entry *core.Entry) string {
 		return "Untracked content"
 	} else if entry.Kind == core.EntryKind_Problematic {
 		return fmt.Sprintf("Problematic content (%s)", entry.Problem)
-	} else {
-		return "<unknown>"
 	}
+	return "<unknown>"
 }
 
 // printConflicts prints a list of synchronization conflicts.

--- a/pkg/configuration/forwarding/configuration.go
+++ b/pkg/configuration/forwarding/configuration.go
@@ -12,17 +12,17 @@ type Configuration struct {
 	Socket struct {
 		// OverwriteMode specifies the default socket overwrite mode to use for
 		// Unix domain socket endpoints.
-		OverwriteMode forwarding.SocketOverwriteMode `yaml:"overwriteMode"`
+		OverwriteMode forwarding.SocketOverwriteMode `yaml:"overwriteMode" mapstructure:"overwriteMode"`
 		// Owner specifies the owner identifier to use for Unix domain listener
 		// sockets.
-		Owner string `yaml:"owner"`
+		Owner string `yaml:"owner" mapstructure:"owner"`
 		// Group specifies the group identifier to use for Unix domain listener
 		// sockets.
-		Group string `yaml:"group"`
+		Group string `yaml:"group" mapstructure:"group"`
 		// PermissionMode specifies the permission mode to use for Unix domain
 		// listener sockets.
-		PermissionMode filesystem.Mode `yaml:"permissionMode"`
-	} `yaml:"socket"`
+		PermissionMode filesystem.Mode `yaml:"permissionMode" mapstructure:"permissionMode"`
+	} `yaml:"socket" mapstructure:"socket"`
 }
 
 // Configuration converts a YAML session configuration to a Protocol Buffers

--- a/pkg/configuration/synchronization/configuration.go
+++ b/pkg/configuration/synchronization/configuration.go
@@ -12,58 +12,58 @@ import (
 // loadable from either TOML or YAML.
 type Configuration struct {
 	// Mode specifies the default synchronization mode.
-	Mode core.SynchronizationMode `yaml:"mode"`
+	Mode core.SynchronizationMode `yaml:"mode" mapstructure:"mode"`
 	// MaximumEntryCount specifies the maximum number of filesystem entries
 	// that endpoints will tolerate managing.
-	MaximumEntryCount uint64 `yaml:"maxEntryCount"`
+	MaximumEntryCount uint64 `yaml:"maxEntryCount" mapstructure:"maxEntryCount"`
 	// MaximumStagingFileSize is the maximum (individual) file size that
 	// endpoints will stage. It can be specified in human-friendly units.
-	MaximumStagingFileSize types.ByteSize `yaml:"maxStagingFileSize"`
+	MaximumStagingFileSize types.ByteSize `yaml:"maxStagingFileSize" mapstructure:"maxStagingFileSize"`
 	// ProbeMode specifies the filesystem probing mode.
-	ProbeMode behavior.ProbeMode `yaml:"probeMode"`
+	ProbeMode behavior.ProbeMode `yaml:"probeMode" mapstructure:"probeMode"`
 	// ScanMode specifies the filesystem scanning mode.
-	ScanMode synchronization.ScanMode `yaml:"scanMode"`
+	ScanMode synchronization.ScanMode `yaml:"scanMode" mapstructure:"scanMode"`
 	// StageMode specifies the filesystem staging mode.
-	StageMode synchronization.StageMode `yaml:"stageMode"`
+	StageMode synchronization.StageMode `yaml:"stageMode" mapstructure:"stageMode"`
 	// Ignore contains parameters related to synchronization ignore
 	// specifications.
 	Ignore struct {
 		// Paths specifies the default list of ignore specifications.
-		Paths []string `yaml:"paths"`
+		Paths []string `yaml:"paths" mapstructure:"paths"`
 		// VCS specifies the VCS ignore mode.
-		VCS core.IgnoreVCSMode `yaml:"vcs"`
-	} `yaml:"ignore"`
+		VCS core.IgnoreVCSMode `yaml:"vcs" mapstructure:"vcs"`
+	} `yaml:"ignore" mapstructure:"ignore"`
 	// Symlink contains parameters related to symbolic link handling.
 	Symlink struct {
 		// Mode specifies the symbolic link mode.
-		Mode core.SymbolicLinkMode `yaml:"mode"`
-	} `yaml:"symlink"`
+		Mode core.SymbolicLinkMode `yaml:"mode" mapstructure:"mode"`
+	} `yaml:"symlink" mapstructure:"symlink"`
 	// Watch contains parameters related to filesystem monitoring.
 	Watch struct {
 		// Mode specifies the file watching mode.
-		Mode synchronization.WatchMode `yaml:"mode"`
+		Mode synchronization.WatchMode `yaml:"mode" mapstructure:"mode"`
 		// PollingInterval specifies the interval (in seconds) for poll-based
 		// file monitoring. A value of 0 specifies that Mutagen's internal
 		// default interval should be used.
-		PollingInterval uint32 `yaml:"pollingInterval"`
-	} `yaml:"watch"`
+		PollingInterval uint32 `yaml:"pollingInterval" mapstructure:"pollingInterval"`
+	} `yaml:"watch" mapstructure:"watch"`
 	// Permissions contains parameters related to permission handling.
 	Permissions struct {
 		// DefaultFileMode specifies the default permission mode to use for new
 		// files in "portable" permission propagation mode.
-		DefaultFileMode filesystem.Mode `yaml:"defaultFileMode"`
+		DefaultFileMode filesystem.Mode `yaml:"defaultFileMode" mapstructure:"defaultFileMode"`
 		// DefaultDirectoryMode specifies the default permission mode to use for
 		// new files in "portable" permission propagation mode.
-		DefaultDirectoryMode filesystem.Mode `yaml:"defaultDirectoryMode"`
+		DefaultDirectoryMode filesystem.Mode `yaml:"defaultDirectoryMode" mapstructure:"defaultDirectoryMode"`
 		// DefaultOwner specifies the default owner identifier to use when
 		// setting ownership of new files and directories in "portable"
 		// permission propagation mode.
-		DefaultOwner string `yaml:"defaultOwner"`
+		DefaultOwner string `yaml:"defaultOwner" mapstructure:"defaultOwner"`
 		// DefaultGroup specifies the default group identifier to use when
 		// setting ownership of new files and directories in "portable"
 		// permission propagation mode.
-		DefaultGroup string `yaml:"defaultGroup"`
-	} `yaml:"permissions"`
+		DefaultGroup string `yaml:"defaultGroup" mapstructure:"defaultGroup"`
+	} `yaml:"permissions" mapstructure:"permissions"`
 }
 
 // Configuration converts a YAML-based session configuration to a Protocol

--- a/pkg/filesystem/temporary.go
+++ b/pkg/filesystem/temporary.go
@@ -1,19 +1,9 @@
 package filesystem
 
-import (
-	"strings"
-)
-
 const (
-	// TemporaryNamePrefix is the file name prefix to use for intermediate
-	// temporary files created by Mutagen. Using this prefix guarantees that any
+	// TemporaryNamePrefix is the file name prefix used for all temporary files
+	// and directories created by Mutagen. Using this prefix guarantees that any
 	// such files will be ignored by filesystem watching and synchronization
-	// scans. It may be suffixed with additional information if desired.
+	// scans. It may be suffixed with additional elements if desired.
 	TemporaryNamePrefix = ".mutagen-temporary-"
 )
-
-// IsTemporaryFileName determines whether or not a file name (not a file path)
-// is the name of an intermediate temporary file used by Mutagen.
-func IsTemporaryFileName(name string) bool {
-	return strings.HasPrefix(name, TemporaryNamePrefix)
-}

--- a/pkg/filesystem/watching/watch.go
+++ b/pkg/filesystem/watching/watch.go
@@ -22,5 +22,5 @@ const (
 	watchCoalescingWindow = 20 * time.Millisecond
 	// watchCoalescingMaximumPendingPaths is the maximum number of paths that
 	// will be allowed in a pending coalesced event.
-	watchCoalescingMaximumPendingPaths = 10 * 1024
+	watchCoalescingMaximumPendingPaths = 128
 )

--- a/pkg/filesystem/watching/watch_recursive_windows.go
+++ b/pkg/filesystem/watching/watch_recursive_windows.go
@@ -220,9 +220,6 @@ func (w *recursiveWatcher) run(ctx context.Context, watchRoot string, initialWat
 			// Convert the event path to be target-relative and replace
 			// backslashes with forward slashes. If the path isn't the target or
 			// a child of the target, then we ignore it.
-			//
-			// TODO: We should raise an error on spurious paths here in order to
-			// keep consistency with other platforms.
 			if path == target {
 				path = ""
 			} else if strings.HasPrefix(path, eventPathTrimPrefix) {

--- a/pkg/forwarding/controller.go
+++ b/pkg/forwarding/controller.go
@@ -282,6 +282,9 @@ func (c *controller) resume(ctx context.Context, prompter string) error {
 		return errors.New("controller disabled")
 	}
 
+	// Perform logging.
+	c.logger.Infof("Resuming")
+
 	// Check if there's an existing forwarding loop (i.e. if the session is
 	// unpaused).
 	if c.cancel != nil {
@@ -424,6 +427,9 @@ func (c *controller) halt(_ context.Context, mode controllerHaltMode, prompter s
 	if c.disabled {
 		return errors.New("controller disabled")
 	}
+
+	// Perform logging.
+	c.logger.Infof(mode.description())
 
 	// Kill any existing forwarding loop.
 	if c.cancel != nil {

--- a/pkg/logging/level.go
+++ b/pkg/logging/level.go
@@ -1,5 +1,9 @@
 package logging
 
+import (
+	"strings"
+)
+
 // Level represents a log level. Its value hierarchy is designed to be ordered
 // and comparable by value.
 type Level uint
@@ -21,6 +25,24 @@ const (
 	// addition to all other execution information and all errors).
 	LevelTrace
 )
+
+// levelNames are the human-readable representations of log levels.
+var levelNames = [6]string{
+	"disabled",
+	"error",
+	"warn",
+	"info",
+	"debug",
+	"trace",
+}
+
+// String provides a human-readable representation of a log level.
+func (l Level) String() string {
+	if l <= LevelTrace {
+		return levelNames[l]
+	}
+	return "unknown"
+}
 
 // NameToLevel converts a string-based representation of a log level to the
 // appropriate Level value. It returns a boolean indicating whether or not the
@@ -44,22 +66,24 @@ func NameToLevel(name string) (Level, bool) {
 	}
 }
 
-// String provides a human-readable representation of a log level.
-func (l Level) String() string {
-	switch l {
-	case LevelDisabled:
-		return "disabled"
-	case LevelError:
-		return "error"
-	case LevelWarn:
-		return "warn"
-	case LevelInfo:
-		return "info"
-	case LevelDebug:
-		return "debug"
-	case LevelTrace:
-		return "trace"
-	default:
-		return "unknown"
+// abbreviations is the range of appreviations to use for log levels.
+const abbreviations = "_EWIDT"
+
+// abbreviation returns a one-byte prefix to use for the level in log lines.
+func (l Level) abbreviation() byte {
+	if l <= LevelTrace {
+		return abbreviations[l]
 	}
+	return '?'
+}
+
+// abbreviationToLevel converts a one-byte prefix representation of a log level
+// to the appropriate Level value. It returns a boolean indicating whether or
+// not the conversion was valid. If the abbreviation is invalid, LevelDisabled
+// is returned.
+func abbreviationToLevel(abbreviation byte) (Level, bool) {
+	if index := strings.IndexByte(abbreviations, abbreviation); index != -1 {
+		return Level(index), true
+	}
+	return LevelDisabled, false
 }

--- a/pkg/sidecar/paths.go
+++ b/pkg/sidecar/paths.go
@@ -1,0 +1,32 @@
+package sidecar
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// VolumeMountPointForPath returns the mount point for the volume on which path
+// resides. If the path does not reside at or beneath a volume mount point, then
+// an empty string is returned. The provided path must be absolute, cleaned, and
+// fully resolved of symbolic links. This function is only valid in the context
+// of a Mutagen sidecar container.
+func VolumeMountPointForPath(path string) string {
+	// Verify that the path exists at or beneath a volume mount point.
+	if !strings.HasPrefix(path, volumeMountParent) || path == volumeMountParent {
+		return ""
+	}
+
+	// Extract the volume name.
+	volume := path[len(volumeMountParent):]
+	if index := strings.IndexByte(volume, filepath.Separator); index >= 0 {
+		volume = volume[:index]
+	}
+
+	// Validate the volume name.
+	if volume == "" {
+		return ""
+	}
+
+	// Compute the volume mount point.
+	return volumeMountParent + volume
+}

--- a/pkg/sidecar/paths_posix.go
+++ b/pkg/sidecar/paths_posix.go
@@ -2,56 +2,6 @@
 
 package sidecar
 
-import (
-	"path/filepath"
-	"strings"
-)
-
-const (
-	// volumeMountParent is the parent path for all volume mounts within a
-	// Mutagen sidecar container.
-	volumeMountParent = "/volumes/"
-)
-
-// PathIsVolumeMountPoint returns whether or not a path is expected to be a
-// volume mount point within a Mutagen sidecar container. If the path is a
-// volume mount point, then the volume name is also returned. The provided path
-// must be absolute, cleaned, and fully resolved of symbolic links. This
-// function is only valid in the context of a Mutagen sidecar container.
-func PathIsVolumeMountPoint(path string) (bool, string) {
-	// Parse the path.
-	directory, leaf := filepath.Split(path)
-
-	// Verify that the parent directory is the volume mount parent and that the
-	// volume name is non-empty.
-	if directory == volumeMountParent && leaf != "" {
-		return true, leaf
-	}
-	return false, ""
-}
-
-// VolumeMountPointForPath returns the mount point for the volume on which path
-// resides. If the path does not reside at or beneath a volume mount point, then
-// an empty string is returned. The provided path must be absolute, cleaned, and
-// fully resolved of symbolic links. This function is only valid in the context
-// of a Mutagen sidecar container.
-func VolumeMountPointForPath(path string) string {
-	// Verify that the path exists at or beneath a volume mount point.
-	if !strings.HasPrefix(path, volumeMountParent) || path == volumeMountParent {
-		return ""
-	}
-
-	// Extract the volume name.
-	volume := path[len(volumeMountParent):]
-	if index := strings.IndexByte(volume, filepath.Separator); index >= 0 {
-		volume = volume[:index]
-	}
-
-	// Validate the volume name.
-	if volume == "" {
-		return ""
-	}
-
-	// Compute the volume mount point.
-	return volumeMountParent + volume
-}
+// volumeMountParent is the parent path for all volume mounts within the sidecar
+// container.
+const volumeMountParent = "/volumes/"

--- a/pkg/sidecar/paths_posix_test.go
+++ b/pkg/sidecar/paths_posix_test.go
@@ -6,50 +6,6 @@ import (
 	"testing"
 )
 
-// TestPathIsVolumeMountPoint tests PathIsVolumeMountPoint.
-func TestPathIsVolumeMountPoint(t *testing.T) {
-	// Define test cases.
-	tests := []struct {
-		path               string
-		expectedVolumeness bool
-		expectedVolumeName string
-	}{
-		{"", false, ""},
-		{"/", false, ""},
-		{"/volume", false, ""},
-		{"/volume/", false, ""},
-		{"/volume/fake", false, ""},
-		{"/whatever", false, ""},
-		{"/whatever ", false, ""},
-		{"/whatever /", false, ""},
-		{"/volumes/", false, ""},
-		{"/volumes/ ", true, " "},
-		{"/volumes/name", true, "name"},
-		{"/volumes/name/", false, ""},
-		{"/volumes/my volume", true, "my volume"},
-		{"/volumes/ volume", true, " volume"},
-		{"/volumes/name/sub", false, ""},
-		{"/volumes/my volume/sub", false, ""},
-		{"/volumes/name/sub/second", false, ""},
-		{"/volumes/my volume/sub/second sub", false, ""},
-	}
-
-	// Process test cases.
-	for i, test := range tests {
-		volumeness, volumeName := PathIsVolumeMountPoint(test.path)
-		if volumeness != test.expectedVolumeness {
-			t.Errorf("test case %d: volumeness does not match expected: %t != %t",
-				i, volumeness, test.expectedVolumeness,
-			)
-		}
-		if volumeName != test.expectedVolumeName {
-			t.Errorf("test case %d: volume name does not match expected: %s != %s",
-				i, volumeName, test.expectedVolumeName,
-			)
-		}
-	}
-}
-
 // TestVolumeMountPointForPath tests VolumeMountPointForPath.
 func TestVolumeMountPointForPath(t *testing.T) {
 	// Define test cases.

--- a/pkg/sidecar/paths_windows.go
+++ b/pkg/sidecar/paths_windows.go
@@ -1,24 +1,5 @@
 package sidecar
 
-import (
-	"path/filepath"
-	"strings"
-)
-
-const (
-	// volumeMountParent is the parent path for all volume mounts within the
-	// sidecar container.
-	volumeMountParent = `c:\volumes\`
-)
-
-// PathIsVolumeMountPoint returns whether or not a path is expected to be a
-// volume mount point within a Mutagen sidecar container. If the path is a
-// volume mount point, then the volume name is also returned. This function is
-// only valid in the context of a Mutagen sidecar container.
-func PathIsVolumeMountPoint(path string) (bool, string) {
-	directory, leaf := filepath.Split(filepath.Clean(path))
-	if strings.EqualFold(directory, volumeMountParent) {
-		return true, leaf
-	}
-	return false, ""
-}
+// volumeMountParent is the parent path for all volume mounts within the sidecar
+// container.
+const volumeMountParent = `c:\volumes\`

--- a/pkg/sidecar/paths_windows_test.go
+++ b/pkg/sidecar/paths_windows_test.go
@@ -1,0 +1,3 @@
+package sidecar
+
+// TODO: Implement tests.

--- a/pkg/stream/valve_writer.go
+++ b/pkg/stream/valve_writer.go
@@ -38,7 +38,8 @@ func (w *ValveWriter) Write(buffer []byte) (int, error) {
 
 // Shut closes the valve and prevents future writes to the underlying writer. It
 // is safe to call Shut concurrently with Write, but doing so will not preempt
-// or unblock pending calls to Write.
+// or unblock pending calls to Write. Calling Shut will release the reference to
+// the underlying writer.
 func (w *ValveWriter) Shut() {
 	// Lock the writer and defer its release.
 	w.writerLock.Lock()

--- a/pkg/synchronization/controller.go
+++ b/pkg/synchronization/controller.go
@@ -1123,13 +1123,28 @@ func (c *controller) synchronize(ctx context.Context, alpha, beta Endpoint) erro
 		)
 		if c.logger.Level() >= logging.LevelTrace {
 			for _, change := range ancestorChanges {
-				c.logger.Tracef("ancestor change at \"%s\"", change.Path)
+				c.logger.Tracef("Ancestor change at \"%s\" from %s to %s",
+					formatPathForLogging(change.Path),
+					formatEntryForLogging(change.Old),
+					formatEntryForLogging(change.New),
+				)
 			}
 			for _, transition := range αTransitions {
-				c.logger.Tracef("alpha transition at \"%s\"", transition.Path)
+				c.logger.Tracef("Alpha transition at \"%s\" from %s to %s",
+					formatPathForLogging(transition.Path),
+					formatEntryForLogging(transition.Old),
+					formatEntryForLogging(transition.New),
+				)
 			}
 			for _, transition := range βTransitions {
-				c.logger.Tracef("beta transition at \"%s\"", transition.Path)
+				c.logger.Tracef("Beta transition at \"%s\" from %s to %s",
+					formatPathForLogging(transition.Path),
+					formatEntryForLogging(transition.Old),
+					formatEntryForLogging(transition.New),
+				)
+			}
+			for _, conflict := range conflicts {
+				c.logger.Tracef("Conflict rooted at %s", conflict.Root)
 			}
 		}
 

--- a/pkg/synchronization/controller.go
+++ b/pkg/synchronization/controller.go
@@ -1085,7 +1085,7 @@ func (c *controller) synchronize(ctx context.Context, alpha, beta Endpoint) erro
 		αContent := αSnapshot.Content
 		βContent := βSnapshot.Content
 		if c.logger.Level() >= logging.LevelTrace {
-			c.logger.Tracef("Ancestor contains %d entries, alpha contains %d entries, beta contains %s entries",
+			c.logger.Tracef("Ancestor contains %d entries, alpha contains %d entries, beta contains %d entries",
 				ancestor.Count(), αContent.Count(), βContent.Count(),
 			)
 		}
@@ -1344,7 +1344,7 @@ func (c *controller) synchronize(ctx context.Context, alpha, beta Endpoint) erro
 		// we're not already in a synchronization cycle that was forced due to
 		// previously missing files.
 		if (αMissingFiles || βMissingFiles) && !skippingPollingDueToMissingFiles {
-			c.logger.Debug("Endpoints missing files after transition, skipping polling")
+			c.logger.Debug("Endpoint(s) missing files after transition, skipping polling")
 			skipPolling = true
 			skippingPollingDueToMissingFiles = true
 		} else {

--- a/pkg/synchronization/core/scan.go
+++ b/pkg/synchronization/core/scan.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 
 	"golang.org/x/text/unicode/norm"
@@ -368,7 +369,7 @@ func (s *scanner) directory(
 		// If this is an intermediate temporary file, then ignore it. We avoid
 		// recording these files, even as untracked entries, because we know
 		// that they're ephemeral.
-		if filesystem.IsTemporaryFileName(contentName) {
+		if strings.HasPrefix(contentName, filesystem.TemporaryNamePrefix) {
 			continue
 		}
 

--- a/pkg/synchronization/core/scan.go
+++ b/pkg/synchronization/core/scan.go
@@ -410,11 +410,20 @@ func (s *scanner) directory(
 			continue
 		}
 
-		// If we have a baseline, then check if that baseline has content with
-		// the same name and kind as what we see on disk. If so, then we can use
-		// that as a baseline for the content.
+		// If this is a directory, and we have a baseline, then check if that
+		// baseline has content with the same name that is also a directory. If
+		// so, then we can use that as a baseline for this content. While we
+		// could do this for all entry types, we restrict this optimization to
+		// directories because they're the only content types for which
+		// rescanning is not O(1). Moreover, we've already paid the price to
+		// grab file metadata, so we may as well compare it with the cache since
+		// that doesn't require another trip to disk. It's true that we are
+		// incurring additional symbolic link reads that we could potentially
+		// replace with baseline content, but they are statistically rarer, they
+		// only require a single system call, and we're only performing them in
+		// directories marked as dirty, so the additional cost is very low.
 		var contentBaseline *Entry
-		if baseline != nil {
+		if contentIsDirectory && baseline != nil {
 			contentBaseline = baseline.Contents[contentName]
 			if contentBaseline != nil && contentBaseline.Kind != contentKind {
 				contentBaseline = nil

--- a/pkg/synchronization/endpoint/local/endpoint.go
+++ b/pkg/synchronization/endpoint/local/endpoint.go
@@ -27,7 +27,7 @@ const (
 	// written to disk in the background.
 	cacheSaveInterval = 60 * time.Second
 	// recheckPathsMaximumCapacity is the maximum re-check path set capacity.
-	recheckPathsMaximumCapacity = 10 * 1024
+	recheckPathsMaximumCapacity = 512
 )
 
 // reifiedWatchMode describes a fully reified watch mode based on the watch mode

--- a/pkg/synchronization/endpoint/local/endpoint.go
+++ b/pkg/synchronization/endpoint/local/endpoint.go
@@ -657,11 +657,10 @@ func (e *endpoint) watchPoll(ctx context.Context, pollingInterval uint32, nonRec
 			changes := core.Diff(previous.Content, snapshot.Content)
 			for _, change := range changes {
 				logger.Tracef("Observed change at \"%s\"", change.Path)
-				if watcher != nil {
-					if change.New.Kind == core.EntryKind_Directory ||
-						change.New.Kind == core.EntryKind_File {
-						watcher.Watch(filepath.Join(e.root, change.Path))
-					}
+				if watcher != nil && change.New != nil &&
+					(change.New.Kind == core.EntryKind_Directory ||
+						change.New.Kind == core.EntryKind_File) {
+					watcher.Watch(filepath.Join(e.root, change.Path))
 				}
 			}
 		}

--- a/pkg/synchronization/endpoint/local/endpoint.go
+++ b/pkg/synchronization/endpoint/local/endpoint.go
@@ -426,7 +426,7 @@ func NewEndpoint(
 		if actualWatchMode == reifiedWatchModePoll {
 			endpoint.watchPoll(workerCtx, watchPollingInterval, nonRecursiveWatchingAllowed)
 		} else if actualWatchMode == reifiedWatchModeRecursive {
-			go endpoint.watchRecursive(workerCtx, watchPollingInterval)
+			endpoint.watchRecursive(workerCtx, watchPollingInterval)
 		}
 		close(watchDone)
 	}()

--- a/pkg/synchronization/logging.go
+++ b/pkg/synchronization/logging.go
@@ -1,0 +1,36 @@
+package synchronization
+
+import (
+	"fmt"
+
+	"github.com/mutagen-io/mutagen/pkg/synchronization/core"
+)
+
+// formatPathForLogging adjusts a path for logging purposes.
+func formatPathForLogging(path string) string {
+	if path == "" {
+		return "<root>"
+	}
+	return path
+}
+
+// formatEntryForLogging formats an entry for logging purposes.
+func formatEntryForLogging(entry *core.Entry) string {
+	if entry == nil {
+		return "<non-existent>"
+	} else if entry.Kind == core.EntryKind_Directory {
+		return fmt.Sprintf("Directory (+%d content entries)", entry.Count()-1)
+	} else if entry.Kind == core.EntryKind_File {
+		if entry.Executable {
+			return fmt.Sprintf("Executable File (Digest %x)", entry.Digest)
+		}
+		return fmt.Sprintf("File (Digest %x)", entry.Digest)
+	} else if entry.Kind == core.EntryKind_SymbolicLink {
+		return fmt.Sprintf("Symbolic Link (Target %s)", entry.Target)
+	} else if entry.Kind == core.EntryKind_Untracked {
+		return "Untracked content"
+	} else if entry.Kind == core.EntryKind_Problematic {
+		return fmt.Sprintf("Problematic content (%s)", entry.Problem)
+	}
+	return "<unknown>"
+}

--- a/sspl/pkg/filesystem/watching/fanotify/watch.go
+++ b/sspl/pkg/filesystem/watching/fanotify/watch.go
@@ -45,7 +45,7 @@ const (
 	watchCoalescingWindow = 20 * time.Millisecond
 	// watchCoalescingMaximumPendingPaths is the maximum number of paths that
 	// will be allowed in a pending coalesced event.
-	watchCoalescingMaximumPendingPaths = 10 * 1024
+	watchCoalescingMaximumPendingPaths = 128
 )
 
 // RecursiveWatcher implements watching.RecursiveWatcher using fanotify.

--- a/sspl/pkg/filesystem/watching/fanotify/watch.go
+++ b/sspl/pkg/filesystem/watching/fanotify/watch.go
@@ -264,19 +264,42 @@ func (w *RecursiveWatcher) run(ctx context.Context, target string, filter func(s
 		case <-ctx.Done():
 			return ErrWatchTerminated
 		case path := <-paths:
-			// Convert the event path to be target-relative. With fanotify,
-			// we're watching the entirety of a filesystem, so certain events
-			// may yield paths outside of the mount point that we're watching.
-			// These paths will manifest as "/", which we'll ignore (unless it's
-			// our watch root).
+			// Convert the event path to be target-relative. We have to ignore
+			// anything that doesn't fall at or below our watch target for two
+			// reasons:
+			//
+			// First, our watch and path resolution location is the mount point,
+			// not necessarily the watch target. Much like on Windows, we have
+			// to watch outside of the target in order to ensure a stable watch
+			// and to ensure that we're seeing changes to the target itself
+			// (though, in this case, we do it more for stability since we know
+			// the volume mounts aren't likely to disappear).
+			//
+			// Second, with fanotify, we're watching an entire filesystem, and
+			// thus we may see events that occur outside of the mount point that
+			// we're watching, especially if that mount point isn't mounting the
+			// filesystem root. If the event can't be referenced by a path
+			// beneath the mount point that we're using with open_by_handle_at,
+			// then a read of its path will result in "/". For example, watching
+			// container volumes that are just bind-mounted directories from the
+			// host filesystem will result in a watch of the entire host
+			// filesystem, but a modification to a path outside of the volume
+			// directory on the host filesystem will yield a notification with
+			// a path resolving to "/" (when resolved relative to the mount
+			// point). This is basically designed to indicate that the event
+			// occurred outside the mount point. Fortunately, as long as the
+			// target location can be referenced by a path beneath the mount
+			// point being used as the reference point for open_by_handle_at, a
+			// valid path will be returned. This means (e.g.) that a single
+			// volume mounted in multiple containers (even at different mount
+			// points) will still yield event notifications with paths relative
+			// to the mount point within the container performing the watch.
 			if path == target {
 				path = ""
 			} else if strings.HasPrefix(path, eventPathTrimPrefix) {
 				path = path[len(eventPathTrimPrefix):]
-			} else if path == "/" {
-				continue
 			} else {
-				return errors.New("event path is not watch target and does not have expected prefix")
+				continue
 			}
 
 			// Check if the path should be excluded.

--- a/tools/scan_bench/main.go
+++ b/tools/scan_bench/main.go
@@ -298,8 +298,9 @@ func main() {
 
 	// Count snapshot content entries.
 	start = time.Now()
-	snapshot.Content.Count()
+	entryCount := snapshot.Content.Count()
 	stop = time.Now()
+	fmt.Println("Snapshot contained", entryCount, "entries")
 	fmt.Println("Snapshot entry counting took", stop.Sub(start))
 
 	// Perform a deep copy of the snapshot contents.


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This pull request contains an assortment of minor tweaks in preparation for the v0.14.x release series.  The primary focus is on logging and log formatting, but there's also an important optimization to sidecar file staging, correctness enforcement for Compose configuration loading, and a small fix for recursive watch Goroutine termination monitoring in the local endpoint implementation.
