### PR TITLE
sync: refactor watch coalescing

### DIFF
--- a/pkg/filesystem/watching/watch.go
+++ b/pkg/filesystem/watching/watch.go
@@ -2,25 +2,12 @@ package watching
 
 import (
 	"errors"
-	"time"
 )
 
 var (
+	// ErrWatchInternalOverflow indicates that a watcher saw an event buffering
+	// overflow in its underlying watching mechanism.
+	ErrWatchInternalOverflow = errors.New("internal event overflow")
 	// ErrWatchTerminated indicates that a watcher has been terminated.
 	ErrWatchTerminated = errors.New("watch terminated")
-	// ErrTooManyPendingPaths indicates that too many paths were coalesced.
-	ErrTooManyPendingPaths = errors.New("too many pending paths")
-)
-
-// Filter is a callback type that can be used to exclude paths from being
-// returned by a watcher. It accepts a path and returns true if that path should
-// be ignored and excluded from events.
-type Filter func(string) bool
-
-const (
-	// watchCoalescingWindow is the time window for event coalescing.
-	watchCoalescingWindow = 20 * time.Millisecond
-	// watchCoalescingMaximumPendingPaths is the maximum number of paths that
-	// will be allowed in a pending coalesced event.
-	watchCoalescingMaximumPendingPaths = 128
 )

--- a/pkg/filesystem/watching/watch_non_recursive.go
+++ b/pkg/filesystem/watching/watch_non_recursive.go
@@ -12,8 +12,8 @@ type NonRecursiveWatcher interface {
 	Watch(path string)
 	// Unwatch removes a path from the list of paths being watched.
 	Unwatch(path string)
-	// Events returns a channel that provides coalesced event notifications.
-	Events() <-chan map[string]bool
+	// Events returns a channel that provides the paths of event notifications.
+	Events() <-chan string
 	// Errors returns a channel that is populated if a watch error occurs. If an
 	// error occurs, then the watcher should be terminated. If Terminate is
 	// invoked before any other error occurs, then it will be populated by

--- a/pkg/filesystem/watching/watch_non_recursive_unsupported.go
+++ b/pkg/filesystem/watching/watch_non_recursive_unsupported.go
@@ -11,6 +11,6 @@ const (
 // NewNonRecursiveWatcher creates a new non-recursive watcher on platforms that
 // support native non-recursive watching. This platform does not support
 // recursive watching and this function will panic if called.
-func NewNonRecursiveWatcher(_ Filter) (NonRecursiveWatcher, error) {
+func NewNonRecursiveWatcher() (NonRecursiveWatcher, error) {
 	panic("non-recursive watching not supported on this platform")
 }

--- a/pkg/filesystem/watching/watch_recursive.go
+++ b/pkg/filesystem/watching/watch_recursive.go
@@ -4,8 +4,8 @@ package watching
 // watching implementations. It is not safe for concurrent usage, though the
 // channels returned by its methods may (and should) be polled simultaneously.
 type RecursiveWatcher interface {
-	// Events returns a channel that provides coalesced event notifications.
-	Events() <-chan map[string]bool
+	// Events returns a channel that provides the paths of event notifications.
+	Events() <-chan string
 	// Errors returns a channel that is populated if a watch error occurs. If an
 	// error occurs, then the watcher should be terminated. If Terminate is
 	// invoked before any other error occurs, then it will be populated by

--- a/pkg/filesystem/watching/watch_recursive_darwin_cgo.go
+++ b/pkg/filesystem/watching/watch_recursive_darwin_cgo.go
@@ -31,7 +31,7 @@ const (
 	// rapid events together. There won't be a significant impact on perceptible
 	// latency because we use the kFSEventStreamCreateFlagNoDefer flag to avoid
 	// coalescing latency on one-shot events.
-	fseventsLatency = 20 * time.Millisecond
+	fseventsLatency = 10 * time.Millisecond
 	// fseventsFlags are the flags to use for FSEvents watches. The inclusion
 	// of the NoDefer (kFSEventStreamCreateFlagNoDefer) flag means that one-shot
 	// events that occur outside of a coalescing window will be delivered

--- a/pkg/filesystem/watching/watch_recursive_darwin_cgo.go
+++ b/pkg/filesystem/watching/watch_recursive_darwin_cgo.go
@@ -26,14 +26,12 @@ const (
 	// more than one event.
 	fseventsChannelCapacity = 50
 	// fseventsLatency is the internal latency (coalescing) parameter to use for
-	// FSEvents watches. We still perform our own coalescing on top of what
-	// FSEvents provides, because FSEvents appears to limit its coalescing to a
-	// maximum of 32 paths. However, there's still value in allowing FSEvents to
-	// perform some coalescing to reduce the overhead of transmitting the events
-	// from the kernel to userspace, and there won't be a significant impact on
-	// overall latency because we use the kFSEventStreamCreateFlagNoDefer flag
-	// to avoid latency on one-shot events.
-	fseventsLatency = 10 * time.Millisecond
+	// FSEvents watches. Setting this to a non-zero value allows FSEvents to
+	// optimize the transfer of events from kernel to user space by grouping
+	// rapid events together. There won't be a significant impact on perceptible
+	// latency because we use the kFSEventStreamCreateFlagNoDefer flag to avoid
+	// coalescing latency on one-shot events.
+	fseventsLatency = 20 * time.Millisecond
 	// fseventsFlags are the flags to use for FSEvents watches. The inclusion
 	// of the NoDefer (kFSEventStreamCreateFlagNoDefer) flag means that one-shot
 	// events that occur outside of a coalescing window will be delivered
@@ -48,7 +46,7 @@ type recursiveWatcher struct {
 	// watch is the underlying FSEvents event stream.
 	watch *fsevents.EventStream
 	// events is the event delivery channel.
-	events chan map[string]bool
+	events chan string
 	// errors is the error delivery channel.
 	errors chan error
 	// cancel is the run loop cancellation function.
@@ -58,10 +56,8 @@ type recursiveWatcher struct {
 }
 
 // NewRecursiveWatcher creates a new FSEvents-based recursive watcher using the
-// specified target path. It accepts an optional filter function that can be
-// used to exclude paths from being returned by the watcher. If filter is nil,
-// then no filtering is performed.
-func NewRecursiveWatcher(target string, filter Filter) (RecursiveWatcher, error) {
+// specified target path.
+func NewRecursiveWatcher(target string) (RecursiveWatcher, error) {
 	// Enforce that the watch target path is absolute. This is necessary because
 	// FSEvents will return event paths as absolute paths rooted at the system
 	// root (at least with the per-host streams that we're using), and thus
@@ -123,7 +119,7 @@ func NewRecursiveWatcher(target string, filter Filter) (RecursiveWatcher, error)
 	// Create the watcher.
 	watcher := &recursiveWatcher{
 		watch:  watch,
-		events: make(chan map[string]bool),
+		events: make(chan string),
 		errors: make(chan error, 1),
 		cancel: cancel,
 	}
@@ -133,7 +129,7 @@ func NewRecursiveWatcher(target string, filter Filter) (RecursiveWatcher, error)
 
 	// Start the run loop.
 	go func() {
-		watcher.errors <- watcher.run(ctx, target, filter)
+		watcher.errors <- watcher.run(ctx, target)
 		watcher.done.Done()
 	}()
 
@@ -142,7 +138,7 @@ func NewRecursiveWatcher(target string, filter Filter) (RecursiveWatcher, error)
 }
 
 // run implements the event processing run loop for recursiveWatcher.
-func (w *recursiveWatcher) run(ctx context.Context, target string, filter Filter) error {
+func (w *recursiveWatcher) run(ctx context.Context, target string) error {
 	// Compute the prefix that we'll need to trim from event paths to make them
 	// target-relative (if they aren't the target itself). Since we called
 	// filepath.EvalSymlinks above, which calls filepath.Clean, we know that
@@ -154,22 +150,6 @@ func (w *recursiveWatcher) run(ctx context.Context, target string, filter Filter
 	} else {
 		eventPathTrimPrefix = target + "/"
 	}
-
-	// Create a coalescing timer, initially stopped and drained, and ensure that
-	// it's stopped once we return.
-	coalescingTimer := time.NewTimer(0)
-	if !coalescingTimer.Stop() {
-		<-coalescingTimer.C
-	}
-	defer coalescingTimer.Stop()
-
-	// Create an empty pending event.
-	pending := make(map[string]bool)
-
-	// Create a separate channel variable to track the target events channel. We
-	// keep it nil to block transmission until the pending event is non-empty
-	// and the coalescing timer has fired.
-	var pendingTarget chan<- map[string]bool
 
 	// Perform event forwarding until cancellation or failure.
 	for {
@@ -195,7 +175,7 @@ func (w *recursiveWatcher) run(ctx context.Context, target string, filter Filter
 				// described above (target divergence) and something that we
 				// can't do much about in general.
 				if event.Flags&fsevents.MustScanSubDirs != 0 {
-					return errors.New("raw events were coalesced")
+					return ErrWatchInternalOverflow
 				} else if event.Flags&fsevents.Mount != 0 {
 					return errors.New("volume mounted under watch root")
 				} else if event.Flags&fsevents.Unmount != 0 {
@@ -212,63 +192,19 @@ func (w *recursiveWatcher) run(ctx context.Context, target string, filter Filter
 					return errors.New("event path is not watch target and does not have expected prefix")
 				}
 
-				// Check if the path should be excluded.
-				if filter != nil && filter(path) {
-					continue
-				}
-
-				// Record the path.
-				pending[path] = true
-
-				// Check if we've exceeded the maximum number of allowed pending
-				// paths. We're technically allowing ourselves to go one over
-				// the limit here, but to avoid that we'd have to check whether
-				// or not each path was already in pending before adding it, and
-				// that would be expensive. Since this is a purely internal
-				// check for the purpose of avoiding excessive memory usage,
-				// this small transient overflow is fine.
-				if len(pending) > watchCoalescingMaximumPendingPaths {
-					return ErrTooManyPendingPaths
-				}
-			}
-
-			// If the pending event is still empty, then there's nothing that we
-			// need to do and we can continue waiting. In this case, we also
-			// know that the coalescing timer isn't (and wasn't) running.
-			if len(pending) == 0 {
-				continue
-			}
-
-			// We may have already had a pending event that was coalesced and
-			// ready to be delivered, but now we've seen more changes and we're
-			// going to create a new coalescing window, so we'll block event
-			// transmission until the new coalescing window is complete.
-			pendingTarget = nil
-
-			// Reset the coalesing timer. We don't know if it was already
-			// running, so we need to drain it in a non-blocking fashion.
-			if !coalescingTimer.Stop() {
+				// Transmit the path.
 				select {
-				case <-coalescingTimer.C:
-				default:
+				case w.events <- path:
+				case <-ctx.Done():
+					return ErrWatchTerminated
 				}
 			}
-			coalescingTimer.Reset(watchCoalescingWindow)
-		case <-coalescingTimer.C:
-			// Set the target events channel to the actual events channel.
-			pendingTarget = w.events
-		case pendingTarget <- pending:
-			// Create a new pending event.
-			pending = make(map[string]bool)
-
-			// Block event transmission until the event is non-empty.
-			pendingTarget = nil
 		}
 	}
 }
 
 // Events implements RecursiveWatcher.Events.
-func (w *recursiveWatcher) Events() <-chan map[string]bool {
+func (w *recursiveWatcher) Events() <-chan string {
 	return w.events
 }
 
@@ -279,7 +215,7 @@ func (w *recursiveWatcher) Errors() <-chan error {
 
 // Terminate implements RecursiveWatcher.Terminate.
 func (w *recursiveWatcher) Terminate() error {
-	// Signal cancellation.
+	// Signal termination.
 	w.cancel()
 
 	// Wait for the run loop to exit.

--- a/pkg/filesystem/watching/watch_recursive_linux_sspl_fanotify.go
+++ b/pkg/filesystem/watching/watch_recursive_linux_sspl_fanotify.go
@@ -12,14 +12,12 @@ var RecursiveWatchingSupported = fanotify.Supported
 
 func init() {
 	// Override the fanotify package's error values.
+	fanotify.ErrWatchInternalOverflow = ErrWatchInternalOverflow
 	fanotify.ErrWatchTerminated = ErrWatchTerminated
-	fanotify.ErrTooManyPendingPaths = ErrTooManyPendingPaths
 }
 
 // NewRecursiveWatcher creates a new fanotify-based recursive watcher using the
-// specified target path. It accepts an optional filter function that can be
-// used to exclude paths from being returned by the watcher. If filter is nil,
-// then no filtering is performed.
-func NewRecursiveWatcher(target string, filter Filter) (RecursiveWatcher, error) {
-	return fanotify.NewRecursiveWatcher(target, filter)
+// specified target path.
+func NewRecursiveWatcher(target string) (RecursiveWatcher, error) {
+	return fanotify.NewRecursiveWatcher(target)
 }

--- a/pkg/filesystem/watching/watch_recursive_unsupported.go
+++ b/pkg/filesystem/watching/watch_recursive_unsupported.go
@@ -9,6 +9,6 @@ const RecursiveWatchingSupported = false
 // NewRecursiveWatcher creates a new recursive watcher on platforms that support
 // native recursive watching. This platform does not support recursive watching
 // and this function will panic if called.
-func NewRecursiveWatcher(_ string, _ Filter) (RecursiveWatcher, error) {
+func NewRecursiveWatcher(_ string) (RecursiveWatcher, error) {
 	panic("recursive watching not supported on this platform")
 }

--- a/pkg/filesystem/watching/watch_test.go
+++ b/pkg/filesystem/watching/watch_test.go
@@ -29,12 +29,8 @@ func verifyWatchEvent(t *testing.T, watcher RecursiveWatcher, paths map[string]b
 	// Perform the waiting operation.
 	for len(paths) > 0 {
 		select {
-		case event := <-watcher.Events():
-			for path := range paths {
-				if event[path] {
-					delete(paths, path)
-				}
-			}
+		case path := <-watcher.Events():
+			delete(paths, path)
 		case err := <-watcher.Errors():
 			t.Fatal("watcher error:", err)
 		case <-deadline.C:
@@ -55,7 +51,7 @@ func TestRecursiveWatcher(t *testing.T) {
 	directory := t.TempDir()
 
 	// Create the watcher and defer its termination.
-	watcher, err := NewRecursiveWatcher(directory, nil)
+	watcher, err := NewRecursiveWatcher(directory)
 	if err != nil {
 		t.Fatal("unable to establish watch:", err)
 	}
@@ -110,7 +106,7 @@ func TestNonRecursiveWatcher(t *testing.T) {
 	directory := t.TempDir()
 
 	// Create the watcher and defer its termination.
-	watcher, err := NewNonRecursiveWatcher(nil)
+	watcher, err := NewNonRecursiveWatcher()
 	if err != nil {
 		t.Fatal("unable to create watcher:", err)
 	}

--- a/pkg/state/coalescer.go
+++ b/pkg/state/coalescer.go
@@ -1,0 +1,106 @@
+package state
+
+import (
+	"context"
+	"time"
+)
+
+// Coalescer performs coalesced signaling, combining multiple signals that occur
+// within a specified time window. A Coalescer is safe for concurrent usage. It
+// maintains a background Goroutine that must be terminated using Terminate.
+type Coalescer struct {
+	// signals is used to transmit signals to the run loop.
+	signals chan struct{}
+	// events is the channel on which events are delivered.
+	events chan struct{}
+	// cancel signals termination to the run loop.
+	cancel context.CancelFunc
+	// done is closed to indicate that the run loop has exited.
+	done chan struct{}
+}
+
+// NewCoalescer creates a new coalescer that will group signals that occur
+// within the specified time window of each other. If window is negative, it
+// will be treated as zero.
+func NewCoalescer(window time.Duration) *Coalescer {
+	// If the specified window is negative, then treat it as zero.
+	if window < 0 {
+		window = 0
+	}
+
+	// Create a cancellable context to regulate the run loop.
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Create the coalescer.
+	coalescer := &Coalescer{
+		signals: make(chan struct{}),
+		events:  make(chan struct{}, 1),
+		cancel:  cancel,
+		done:    make(chan struct{}),
+	}
+
+	// Start the coalescer's run loop.
+	go coalescer.run(ctx, window)
+
+	// Done.
+	return coalescer
+}
+
+// run implements the signal processing run loop for Coalescer.
+func (c *Coalescer) run(ctx context.Context, window time.Duration) {
+	// Create the (initially stopped) coalescing timer.
+	timer := time.NewTimer(0)
+	if !timer.Stop() {
+		<-timer.C
+	}
+
+	// Loop and process events until cancelled.
+	for {
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			close(c.done)
+			return
+		case <-c.signals:
+			timer.Stop()
+			select {
+			case <-timer.C:
+			default:
+			}
+			timer.Reset(window)
+		case <-timer.C:
+			select {
+			case c.events <- struct{}{}:
+			default:
+			}
+		}
+	}
+}
+
+// Strobe enqueues a signal to be sent after the coalescing window. If a
+// subsequent call to Strobe is made within the coalescing window, then it will
+// reset the coalescing timer and an event will only be sent after Strobe hasn't
+// been called for the coalescing window period.
+func (c *Coalescer) Strobe() {
+	select {
+	case c.signals <- struct{}{}:
+	case <-c.done:
+	}
+}
+
+// Events returns the signal notification channel. This channel is buffered with
+// a capacity of 1, so no signals will ever be lost if it's not actively polled.
+// The resulting channel is never closed.
+func (c *Coalescer) Events() <-chan struct{} {
+	return c.events
+}
+
+// Terminate shuts down the coalescer's internal run loop and waits for it to
+// terminate. It's safe to continue invoking other methods after invoking
+// Terminate (including Terminate, which is idempotent), though Strobe will have
+// no effect and only previously buffered events will be delivered on the
+// channel returned by Events.
+func (c *Coalescer) Terminate() {
+	c.cancel()
+	<-c.done
+}

--- a/pkg/state/coalescer_test.go
+++ b/pkg/state/coalescer_test.go
@@ -1,0 +1,3 @@
+package state
+
+// TODO: Implement tests.

--- a/pkg/synchronization/controller.go
+++ b/pkg/synchronization/controller.go
@@ -1105,11 +1105,15 @@ func (c *controller) synchronize(ctx context.Context, alpha, beta Endpoint) erro
 
 		// If one side preserves executability and the other does not, then
 		// propagate executability from the preserving side to the
-		// non-preserving side.
-		if αSnapshot.PreservesExecutability && !βSnapshot.PreservesExecutability {
+		// non-preserving side. We only do this if the corresponding target
+		// content is non-nil, because (a) PropagateExecutability is a no-op if
+		// it is nil and (b) PreservesExecutability will have defaulted to false
+		// if there's no content and (even though this will be a no-op) we don't
+		// want the spurious logs.
+		if αSnapshot.PreservesExecutability && βContent != nil && !βSnapshot.PreservesExecutability {
 			c.logger.Debug("Propagating alpha executability to beta")
 			βContent = core.PropagateExecutability(ancestor, αContent, βContent)
-		} else if βSnapshot.PreservesExecutability && !αSnapshot.PreservesExecutability {
+		} else if βSnapshot.PreservesExecutability && αContent != nil && !αSnapshot.PreservesExecutability {
 			c.logger.Debug("Propagating beta executability to alpha")
 			αContent = core.PropagateExecutability(ancestor, βContent, αContent)
 		}

--- a/pkg/synchronization/controller.go
+++ b/pkg/synchronization/controller.go
@@ -1163,7 +1163,9 @@ func (c *controller) synchronize(ctx context.Context, alpha, beta Endpoint) erro
 				)
 			}
 			for _, conflict := range conflicts {
-				c.logger.Tracef("Conflict rooted at %s", conflict.Root)
+				c.logger.Tracef("Conflict rooted at \"%s\"",
+					formatPathForLogging(conflict.Root),
+				)
 			}
 		}
 

--- a/pkg/synchronization/core/scan.go
+++ b/pkg/synchronization/core/scan.go
@@ -660,7 +660,8 @@ func Scan(
 	// If a baseline has been provided but differs in terms of root kind or
 	// filesystem behavior, then we can just ignore it.
 	if baseline != nil {
-		baselineInvalid := baseline.Content.Kind != rootKind ||
+		baselineInvalid := baseline.Content == nil ||
+			baseline.Content.Kind != rootKind ||
 			baseline.PreservesExecutability != preservesExecutability ||
 			baseline.DecomposesUnicode != decomposesUnicode
 		if baselineInvalid {

--- a/pkg/synchronization/endpoint/local/endpoint.go
+++ b/pkg/synchronization/endpoint/local/endpoint.go
@@ -29,11 +29,11 @@ const (
 	pollSignalCoalescingWindow = 20 * time.Millisecond
 	// minimumCacheSaveInterval is the minimum interval at which caches are
 	// written to disk asynchronously.
-	minimumCacheSaveInterval = 60 * time.Second
+	minimumCacheSaveInterval = 20 * time.Second
 	// watchPollScanSignalCoalescingWindow is the time interval over which
 	// triggering of scan operations by the non-recursive watch in watchPoll
 	// will be coalesced.
-	watchPollScanSignalCoalescingWindow = 20 * time.Millisecond
+	watchPollScanSignalCoalescingWindow = 10 * time.Millisecond
 )
 
 // reifiedWatchMode describes a fully reified watch mode based on the watch mode

--- a/pkg/synchronization/endpoint/local/endpoint.go
+++ b/pkg/synchronization/endpoint/local/endpoint.go
@@ -17,17 +17,23 @@ import (
 	"github.com/mutagen-io/mutagen/pkg/filesystem/watching"
 	"github.com/mutagen-io/mutagen/pkg/logging"
 	"github.com/mutagen-io/mutagen/pkg/sidecar"
+	"github.com/mutagen-io/mutagen/pkg/state"
 	"github.com/mutagen-io/mutagen/pkg/synchronization"
 	"github.com/mutagen-io/mutagen/pkg/synchronization/core"
 	"github.com/mutagen-io/mutagen/pkg/synchronization/rsync"
 )
 
 const (
-	// cacheSaveInterval is the interval at which caches are serialized and
-	// written to disk in the background.
-	cacheSaveInterval = 60 * time.Second
-	// recheckPathsMaximumCapacity is the maximum re-check path set capacity.
-	recheckPathsMaximumCapacity = 512
+	// pollSignalCoalescingWindow is the time interval over which triggering of
+	// the polling channel will be coalesced.
+	pollSignalCoalescingWindow = 20 * time.Millisecond
+	// minimumCacheSaveInterval is the minimum interval at which caches are
+	// written to disk asynchronously.
+	minimumCacheSaveInterval = 60 * time.Second
+	// watchPollScanSignalCoalescingWindow is the time interval over which
+	// triggering of scan operations by the non-recursive watch in watchPoll
+	// will be coalesced.
+	watchPollScanSignalCoalescingWindow = 20 * time.Millisecond
 )
 
 // reifiedWatchMode describes a fully reified watch mode based on the watch mode
@@ -89,6 +95,11 @@ type endpoint struct {
 	// workerCancel cancels any background worker Goroutines for the endpoint.
 	// This field is static and thus safe for concurrent invocation.
 	workerCancel context.CancelFunc
+	// saveCacheSignal is used to signal to the cache saving Goroutine that a
+	// cache save operation should occur. It is buffered with a capacity of 1
+	// and should be written to in a non-blocking fashion. It is never closed.
+	// This field is static and thus safe for concurrent usage.
+	saveCacheSignal chan<- struct{}
 	// saveCacheDone is closed when the cache saving Goroutine has completed. It
 	// will never have values written to it and will only be closed, so a
 	// receive that returns indicates closure. This field is static and thus
@@ -99,13 +110,9 @@ type endpoint struct {
 	// that returns indicates closure. This field is static and thus safe for
 	// concurrent receive operations.
 	watchDone <-chan struct{}
-	// pollEvents is the channel used to inform a call to Poll that there are
-	// filesystem modifications (and thus it can return). It is a buffered
-	// channel with a capacity of one. Senders should always perform a
-	// non-blocking send to the channel, because if it is already populated,
-	// then filesystem modifications are already indicated. This field is static
-	// and never closed, and is thus safe for concurrent send operations.
-	pollEvents chan struct{}
+	// pollSignal is the coalescer used to signal Poll callers. This field is
+	// static and thus safe for concurrent usage.
+	pollSignal *state.Coalescer
 	// recursiveWatchRetryEstablish is a channel used by Transition to signal to
 	// the recursive watching Goroutine (if any) that it should try to
 	// re-establish watching. It is a non-buffered channel, with reads only
@@ -120,7 +127,11 @@ type endpoint struct {
 	// scannedSinceLastStageCall, and scannedSinceLastTransitionCall. This lock
 	// is not necessitated by the Endpoint interface (which doesn't permit
 	// concurrent usage), but rather the endpoint's background worker Goroutines
-	// for cache saving and filesystem watching.
+	// for cache saving and filesystem watching. This lock also notably excludes
+	// coverage of lastReturnedScanCache and
+	// lastReturnedScanSnapshotDecomposesUnicode, which are only updated by Scan
+	// and read by Transition, thus making them safe under Endpoint's documented
+	// lack of support for concurrent invocation.
 	scanLock sync.Mutex
 	// accelerate indicates that the Scan function should attempt to accelerate
 	// scanning by using data from a background watcher Goroutine.
@@ -149,6 +160,16 @@ type endpoint struct {
 	// scannedSinceLastTransitionCall tracks whether or not a scan operation has
 	// occurred since the last transitioning operation.
 	scannedSinceLastTransitionCall bool
+	// lastReturnedScanCache is the cache corresponding to the last snapshot
+	// returned by Scan. This may be different than cache and is tracked
+	// separately because Transition (in order to function correctly) requires
+	// the cache corresponding to the snapshot that resulted in its operations.
+	lastReturnedScanCache *core.Cache
+	// lastReturnedScanSnapshotDecomposesUnicode is the value of
+	// DecomposesUnicode from the last snapshot returned by Scan. Despite very
+	// likely being the same as the value in the current snapshot, it needs to
+	// be tracked separately for the same reasons as lastReturnedScanCache.
+	lastReturnedScanSnapshotDecomposesUnicode bool
 	// stager is the staging coordinator. It is not safe for concurrent usage,
 	// but since Endpoint doesn't allow concurrent usage, we know that the
 	// stager will only be used in at most one of Stage or Transition methods at
@@ -376,8 +397,11 @@ func NewEndpoint(
 	// Goroutines will operate.
 	workerCtx, workerCancel := context.WithCancel(context.Background())
 
-	// Create channels to monitor background worker Goroutine completion.
+	// Create channels to signal and track the cache saving Goroutine.
+	saveCacheSignal := make(chan struct{}, 1)
 	saveCacheDone := make(chan struct{})
+
+	// Create a channel to track the watch Goroutine.
 	watchDone := make(chan struct{})
 
 	// Create the endpoint.
@@ -395,9 +419,10 @@ func NewEndpoint(
 		defaultDirectoryMode:         defaultDirectoryMode,
 		defaultOwnership:             defaultOwnership,
 		workerCancel:                 workerCancel,
+		saveCacheSignal:              saveCacheSignal,
 		saveCacheDone:                saveCacheDone,
 		watchDone:                    watchDone,
-		pollEvents:                   make(chan struct{}, 1),
+		pollSignal:                   state.NewCoalescer(pollSignalCoalescingWindow),
 		recursiveWatchRetryEstablish: make(chan struct{}),
 		hasher:                       version.Hasher(),
 		cache:                        cache,
@@ -411,7 +436,7 @@ func NewEndpoint(
 
 	// Start the cache saving Goroutine.
 	go func() {
-		endpoint.saveCacheRegularly(workerCtx, cachePath)
+		endpoint.saveCacheRegularly(workerCtx, cachePath, saveCacheSignal)
 		close(saveCacheDone)
 	}()
 
@@ -437,35 +462,55 @@ func NewEndpoint(
 
 // saveCacheRegularly serializes the cache and writes the result to disk at
 // regular intervals. It runs as a background Goroutine for all endpoints.
-func (e *endpoint) saveCacheRegularly(ctx context.Context, cachePath string) {
-	// Create a ticker to regulate cache saving and defer its shutdown.
-	ticker := time.NewTicker(cacheSaveInterval)
-	defer ticker.Stop()
-
+func (e *endpoint) saveCacheRegularly(ctx context.Context, cachePath string, signal <-chan struct{}) {
 	// Track the last saved cache. If it hasn't changed, there's no point in
 	// rewriting it. It's safe to keep a reference to the cache since caches are
-	// treated as immutable. The only cost is keeping an old cache around until
-	// the next write cycle, but that's a relatively small price to pay to avoid
-	// unnecessary disk writes.
+	// treated as immutable. The only cost is (possibly) keeping an old cache
+	// around until the next write cycle, but that's a relatively small price to
+	// pay to avoid unnecessary disk writes, and in the common case of
+	// accelerated scanning with no re-check paths, a new cache won't be
+	// generated anyway, so we won't be carrying anything extra around.
 	var lastSavedCache *core.Cache
 
-	// Loop indefinitely, watching for cancellation and saving the cache to
-	// disk at regular intervals. If we see a cache write failure, we record it,
-	// and we don't attempt any more saves. The recorded error will be reported
-	// to the controller on the next call to Scan.
+	// Track the last cache save time.
+	var lastSaveTime time.Time
+
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-ticker.C:
-			e.scanLock.Lock()
-			if e.cacheWriteError == nil && e.cache != lastSavedCache {
-				if err := encoding.MarshalAndSaveProtobuf(cachePath, e.cache); err != nil {
-					e.cacheWriteError = err
-				} else {
-					lastSavedCache = e.cache
-				}
+		case <-signal:
+			// If it's been less than our minimum cache save interval, then skip
+			// this save request.
+			now := time.Now()
+			if now.Sub(lastSaveTime) < minimumCacheSaveInterval {
+				continue
 			}
+
+			// Grab the scan lock.
+			e.scanLock.Lock()
+
+			// If the cache hasn't changed since the last write, then skip this
+			// save request.
+			if e.cache == lastSavedCache {
+				e.scanLock.Unlock()
+				continue
+			}
+
+			// Save the cache.
+			e.logger.Debug("Saving cache to disk")
+			if err := encoding.MarshalAndSaveProtobuf(cachePath, e.cache); err != nil {
+				e.logger.Error("Cache save failed:", err)
+				e.cacheWriteError = err
+				e.scanLock.Unlock()
+				return
+			}
+
+			// Update our state.
+			lastSavedCache = e.cache
+			lastSaveTime = now
+
+			// Release the cache lock.
 			e.scanLock.Unlock()
 		}
 	}
@@ -501,28 +546,15 @@ func (e *endpoint) watchPoll(ctx context.Context, pollingInterval uint32, nonRec
 	previous := &core.Snapshot{}
 
 	// If non-recursive watching is available, then set up a non-recursive
-	// watcher. Since non-recursive watching is a best-effort basis to reduce
-	// latency, we don't try to re-establish this watcher if it fails.
+	// watcher (and ensure its termination). Since non-recursive watching is a
+	// best-effort basis to reduce latency, we don't try to re-establish this
+	// watcher if it fails.
 	var watcher watching.NonRecursiveWatcher
-	var watchEvents <-chan map[string]bool
+	var watchEvents <-chan string
 	var watchErrors <-chan error
 	if nonRecursiveWatchingAllowed && watching.NonRecursiveWatchingSupported {
-		// Create the filter that we'll use to exclude Mutagen temporary files.
-		// In the non-recursive watching case, we can't use the fast-path base
-		// name calculation for leaf name calculations (at least not safely)
-		// because our non-recursive watchers don't ensure root-relativity.
-		// Fortunately, we don't need to perform the same total path prefix
-		// check as recursive watching since we know that temporary directories
-		// will never be added to the non-recursive watcher since they'll never
-		// be included in the scan, and thus we'll never see changes to their
-		// contents that would need to be filtered out.
-		filter := func(path string) bool {
-			return strings.HasPrefix(filepath.Base(path), filesystem.TemporaryNamePrefix)
-		}
-
-		// Attempt to create the watcher and ensure that it will be terminated.
 		logger.Debug("Creating non-recursive watcher")
-		if w, err := watching.NewNonRecursiveWatcher(filter); err != nil {
+		if w, err := watching.NewNonRecursiveWatcher(); err != nil {
 			logger.Debug("Unable to create non-recursive watcher:", err)
 		} else {
 			logger.Debug("Successfully created non-recursive watcher")
@@ -536,6 +568,13 @@ func (e *endpoint) watchPoll(ctx context.Context, pollingInterval uint32, nonRec
 			}()
 		}
 	}
+
+	// Create (and defer termination of) a coalescer that we can use to drive
+	// polling when using non-recursive watching. This is only required if a
+	// non-recursive watcher is established, but tracking an event channel and
+	// strobe method conditionally would make this code even uglier.
+	performScanSignal := state.NewCoalescer(watchPollScanSignalCoalescingWindow)
+	defer performScanSignal.Terminate()
 
 	// Loop until cancellation, performing polling at the specified interval.
 	for {
@@ -580,7 +619,9 @@ func (e *endpoint) watchPoll(ctx context.Context, pollingInterval uint32, nonRec
 				// Terminate polling.
 				return
 			case <-ticker.C:
-				logger.Debug("Received polling signal")
+				logger.Debug("Received timer-based polling signal")
+			case <-performScanSignal.Events():
+				logger.Debug("Received event-driven polling signal")
 			case err := <-watchErrors:
 				// Log the error.
 				logger.Debug("Non-recursive watching error:", err)
@@ -595,16 +636,30 @@ func (e *endpoint) watchPoll(ctx context.Context, pollingInterval uint32, nonRec
 				watcher = nil
 				watchErrors = nil
 
-				// Continue polling.
+				// Strobe the re-scan signal an continue polling.
+				performScanSignal.Strobe()
 				continue
-			case event := <-watchEvents:
-				// Log the event.
-				logger.Debug("Received event with", len(event), "paths")
-				if logger.Level() >= logging.LevelTrace {
-					for path := range event {
-						logger.Tracef("Received event path: \"%s\"", path)
-					}
+			case path := <-watchEvents:
+				// Filter temporary files and log the event. Non-recursive
+				// watchers return absolute paths, and thus we can't use our
+				// fast-path base name calculation for leaf name calculations.
+				// Fortunately, we don't need to perform the same total path
+				// prefix check as recursive watching since we know that
+				// temporary directories will never be added to the watcher
+				// (since they'll never be included in the scan), and thus we'll
+				// never see changes to their contents that would need to be
+				// filtered out.
+				ignore := strings.HasPrefix(filepath.Base(path), filesystem.TemporaryNamePrefix)
+				if ignore {
+					logger.Tracef("Ignoring event path: \"%s\"", path)
+					continue
+				} else {
+					logger.Tracef("Processing event path: \"%s\"", path)
 				}
+
+				// Strobe the re-scan signal and continue polling.
+				performScanSignal.Strobe()
+				continue
 			}
 		}
 
@@ -626,8 +681,8 @@ func (e *endpoint) watchPoll(ctx context.Context, pollingInterval uint32, nonRec
 			// Release the scan lock.
 			e.scanLock.Unlock()
 
-			// Strobe the poll events channel and continue polling.
-			e.strobePollEvents()
+			// Strobe the poll signal and continue polling.
+			e.pollSignal.Strobe()
 			continue
 		}
 
@@ -674,8 +729,8 @@ func (e *endpoint) watchPoll(ctx context.Context, pollingInterval uint32, nonRec
 			// Log the modifications.
 			logger.Debug("Modifications detected")
 
-			// Strobe the poll events channel.
-			e.strobePollEvents()
+			// Strobe the poll signal.
+			e.pollSignal.Strobe()
 		} else {
 			// Log the lack of modifications.
 			logger.Debug("No unignored modifications detected")
@@ -700,16 +755,6 @@ func (e *endpoint) watchRecursive(ctx context.Context, pollingInterval uint32) {
 		}
 	}()
 
-	// Create the filter that we'll use to exclude Mutagen temporary files.
-	// Recursive watchers can use our fast-path base name calculation for leaf
-	// name calculations. We also check the entire path for a temporary prefix
-	// to identify temporary directories (whose contents may have non-temporary
-	// names, such as internal staging directories).
-	filter := func(path string) bool {
-		return strings.HasPrefix(path, filesystem.TemporaryNamePrefix) ||
-			strings.HasPrefix(core.PathBase(path), filesystem.TemporaryNamePrefix)
-	}
-
 	// Create a timer, initially stopped and drained, that we can use to
 	// regulate waiting periods. Also, ensure that it's stopped when we return.
 	timer := time.NewTimer(0)
@@ -722,14 +767,14 @@ WatchEstablishment:
 	for {
 		// Attempt to establish the watch.
 		logger.Debug("Attempting to establish recursive watch")
-		watcher, err = watching.NewRecursiveWatcher(e.root, filter)
+		watcher, err = watching.NewRecursiveWatcher(e.root)
 		if err != nil {
 			// Log the failure.
 			logger.Debug("Unable to establish recursive watch:", err)
 
-			// Strobe poll events (since nothing else will be driving
+			// Strobe the poll signal (since nothing else will be driving
 			// synchronization from this endpoint at this point in time).
-			e.strobePollEvents()
+			e.pollSignal.Strobe()
 
 			// Wait to retry watch establishment.
 			timer.Reset(pollingDuration)
@@ -747,15 +792,18 @@ WatchEstablishment:
 		}
 		logger.Debug("Watch successfully established")
 
-		// Strobe the poll events channel to signal that we now know the
-		// synchronization root exists and is accessible.
-		e.strobePollEvents()
-
 		// If accelerated scanning is allowed, then reset the timer (which won't
 		// be running) to fire immediately in the event loop in order to try
-		// enabling acceleration.
+		// enabling acceleration. The handler for the timer will take care of
+		// strobing the poll signal once the scan is done (that way there's not
+		// immediate contention for the scan lock). If accelerated scanning
+		// isn't allowed, then just strobe the poll signal here since
+		// establishment of the watch is worth signaling (and necessary on the
+		// first pass through the loop).
 		if e.accelerationAllowed {
 			timer.Reset(0)
+		} else {
+			e.pollSignal.Strobe()
 		}
 
 		// Loop and process events.
@@ -790,82 +838,85 @@ WatchEstablishment:
 					e.recheckPaths = make(map[string]bool)
 				}
 				e.scanLock.Unlock()
+
+				// Strobe the poll signal, regardless of outcome. The likely
+				// outcome is that we succeeded in enabling acceleration, but
+				// even if not, we'll still want to drive a synchronization
+				// cycle if this is the first pass through the loop.
+				e.pollSignal.Strobe()
 			case err := <-watcher.Errors():
 				// Log the error.
 				logger.Debug("Recursive watching error:", err)
 
 				// If acceleration is allowed on the endpoint, then disable scan
-				// acceleration and clear out the re-check paths. Moreover,
-				// always grab the scan lock, even if acceleration isn't allowed
-				// (which we could check without holding the lock) because
-				// there's a very high likelihood that the watch failure was
-				// caused by Transition, and thus waiting for the scan lock to
-				// become available will ensure that we don't rapidly loop and
-				// re-establish watches that are likely to fail while Transition
-				// is still operating.
-				e.scanLock.Lock()
+				// acceleration and clear out the re-check paths.
 				if e.accelerationAllowed {
+					e.scanLock.Lock()
 					e.accelerate = false
 					e.recheckPaths = nil
+					e.scanLock.Unlock()
 				}
-				e.scanLock.Unlock()
 
 				// Stop and drain the timer, which may be running.
 				stopAndDrainTimer(timer)
 
-				// Strobe the poll events channel since something has occurred
-				// (likely on disk) that's killed our watch.
-				e.strobePollEvents()
+				// Strobe the poll signal since something has occurred that's
+				// killed our watch.
+				e.pollSignal.Strobe()
 
-				// Terminate the watcher and restart watch establishment.
+				// Terminate the watcher.
 				watcher.Terminate()
 				watcher = nil
-				continue WatchEstablishment
-			case event := <-watcher.Events():
-				// Log the event.
-				logger.Debug("Received event with", len(event), "paths")
-				if logger.Level() >= logging.LevelTrace {
-					for path := range event {
-						logger.Tracef("Received event path: \"%s\"", path)
+
+				// If the watcher failed due to an internal event overflow, then
+				// events are likely happening on disk faster than we can
+				// process them. In that case, wait one polling interval before
+				// attempting to re-establish the watch.
+				if err == watching.ErrWatchInternalOverflow {
+					logger.Debug("Waiting before watch re-establishment")
+					timer.Reset(pollingDuration)
+					select {
+					case <-ctx.Done():
+						return
+					case <-timer.C:
 					}
 				}
 
-				// If acceleration is allowed (and available) on the endpoint,
-				// then register the event's paths as re-check paths. We only
+				// Retry watch establishment.
+				continue WatchEstablishment
+			case path := <-watcher.Events():
+				// Filter temporary files and log the event. Recursive watchers
+				// return watch-root-relative paths, so we can use our fast-path
+				// base name calculation for leaf name calculations. We also
+				// check the entire path for a temporary prefix to identify
+				// temporary directories (whose contents may have non-temporary
+				// names, such as in the case of internal staging directories).
+				ignore := strings.HasPrefix(path, filesystem.TemporaryNamePrefix) ||
+					strings.HasPrefix(core.PathBase(path), filesystem.TemporaryNamePrefix)
+				if ignore {
+					logger.Tracef("Ignoring event path: \"%s\"", path)
+					continue
+				} else {
+					logger.Tracef("Processing event path: \"%s\"", path)
+				}
+
+				// If acceleration is allowed (and currently available) on the
+				// endpoint, then register the path as a re-check path. We only
 				// need to do this if acceleration is already available,
 				// otherwise we're still in a pre-baseline scan state and don't
-				// need to record these events. If we overflow the maximum
-				// re-check path set size, then we'll disable acceleration and
-				// schedule an immediate scan to re-enable acceleration.
+				// need to record these events.
 				if e.accelerationAllowed {
 					e.scanLock.Lock()
 					if e.accelerate {
-						for path := range event {
-							e.recheckPaths[path] = true
-							if len(e.recheckPaths) > recheckPathsMaximumCapacity {
-								logger.Debug("Re-check paths overflowed maximum capacity")
-								e.accelerate = false
-								e.recheckPaths = nil
-								timer.Reset(0)
-								break
-							}
-						}
+						e.recheckPaths[path] = true
 					}
 					e.scanLock.Unlock()
 				}
 
-				// Strobe the poll events channel to signal the event.
-				e.strobePollEvents()
+				// Strobe the poll signal to signal the event.
+				e.pollSignal.Strobe()
 			}
 		}
-	}
-}
-
-// strobePollEvents strobes the pollEvents channel in a non-blocking fashion.
-func (e *endpoint) strobePollEvents() {
-	select {
-	case e.pollEvents <- struct{}{}:
-	default:
 	}
 }
 
@@ -874,7 +925,7 @@ func (e *endpoint) Poll(ctx context.Context) error {
 	// Wait for either cancellation or an event.
 	select {
 	case <-ctx.Done():
-	case <-e.pollEvents:
+	case <-e.pollSignal.Events():
 	}
 
 	// Done.
@@ -911,6 +962,12 @@ func (e *endpoint) scan(ctx context.Context, baseline *core.Snapshot, recheckPat
 	// Update call states.
 	e.scannedSinceLastStageCall = true
 	e.scannedSinceLastTransitionCall = true
+
+	// Trigger an asynchronous cache save operation.
+	select {
+	case e.saveCacheSignal <- struct{}{}:
+	default:
+	}
 
 	// Success.
 	return nil
@@ -976,6 +1033,10 @@ func (e *endpoint) Scan(ctx context.Context, _ *core.Entry, full bool) (*core.Sn
 		)
 		return nil, errors.New("exceeded allowed entry count"), true
 	}
+
+	// Store the values corresponding to the snapshot that we'll return.
+	e.lastReturnedScanCache = e.cache
+	e.lastReturnedScanSnapshotDecomposesUnicode = e.snapshot.DecomposesUnicode
 
 	// Success.
 	return e.snapshot, nil, false
@@ -1180,19 +1241,28 @@ func (e *endpoint) Transition(ctx context.Context, transitions []*core.Change) (
 		}
 	}
 
-	// Perform the transition.
+	// Perform the transition. We release the scan lock around this operation
+	// because we want watching Goroutines to be able to pick up events, or at
+	// least be able to handle them. If we held scan lock, there's a good chance
+	// that the underlying watchers would overflow while they waited for event
+	// paths to be handled. Note that we don't need to hold the scan lock to
+	// read lastReturnedScanCache and lastReturnedScanSnapshotDecomposesUnicode
+	// because these aren't updated concurrently and thus don't fall under the
+	// scope of the scan lock.
+	e.scanLock.Unlock()
 	results, problems, stagerMissingFiles := core.Transition(
 		ctx,
 		e.root,
 		transitions,
-		e.cache,
+		e.lastReturnedScanCache,
 		e.symbolicLinkMode,
 		e.defaultFileMode,
 		e.defaultDirectoryMode,
 		e.defaultOwnership,
-		e.snapshot.DecomposesUnicode,
+		e.lastReturnedScanSnapshotDecomposesUnicode,
 		e.stager,
 	)
+	e.scanLock.Lock()
 
 	// Determine whether or not the transition made any changes on disk.
 	var transitionMadeChanges bool
@@ -1243,16 +1313,11 @@ func (e *endpoint) Transition(ctx context.Context, transitions []*core.Change) (
 		} else if e.watchMode == reifiedWatchModeRecursive {
 			for _, transition := range transitions {
 				e.recheckPaths[transition.Path] = true
-				if len(e.recheckPaths) > recheckPathsMaximumCapacity {
-					e.accelerate = false
-					e.recheckPaths = nil
-					break
-				}
 			}
 		}
 	}
 
-	// If we're using poll-based watching, then strobe the polling channel if
+	// If we're using poll-based watching, then strobe the poll signal if
 	// Transition made any changes on disk. This is necessary to work around
 	// cases where some other mechanism rapidly (and fully) inverts changes, in
 	// which case the pre-Transition and post-Transition scans will look the
@@ -1272,7 +1337,7 @@ func (e *endpoint) Transition(ctx context.Context, transitions []*core.Change) (
 	// loop when problems are encountered for changes that can never be fully
 	// applied.
 	if e.watchMode == reifiedWatchModePoll && transitionMadeChanges {
-		e.strobePollEvents()
+		e.pollSignal.Strobe()
 	}
 
 	// Wipe the staging directory. We don't monitor for errors here, because we
@@ -1298,6 +1363,9 @@ func (e *endpoint) Shutdown() error {
 	// Wait for background worker Goroutines to terminate.
 	<-e.saveCacheDone
 	<-e.watchDone
+
+	// Terminate the polling coalescer.
+	e.pollSignal.Terminate()
 
 	// Done.
 	return nil

--- a/pkg/synchronization/endpoint/local/endpoint.go
+++ b/pkg/synchronization/endpoint/local/endpoint.go
@@ -620,7 +620,7 @@ func (e *endpoint) watchPoll(ctx context.Context, pollingInterval uint32, nonRec
 				return
 			case <-ticker.C:
 				logger.Debug("Received timer-based polling signal")
-			case <-performScanSignal.Events():
+			case <-performScanSignal.Signals():
 				logger.Debug("Received event-driven polling signal")
 			case err := <-watchErrors:
 				// Log the error.
@@ -925,7 +925,7 @@ func (e *endpoint) Poll(ctx context.Context) error {
 	// Wait for either cancellation or an event.
 	select {
 	case <-ctx.Done():
-	case <-e.pollSignal.Events():
+	case <-e.pollSignal.Signals():
 	}
 
 	// Done.

--- a/sspl/pkg/filesystem/watching/fanotify/fanotify.go
+++ b/sspl/pkg/filesystem/watching/fanotify/fanotify.go
@@ -174,7 +174,7 @@ func processEvent(mountFD int, buffer []byte) ([]byte, string, error) {
 	// event information structure (or at least the fanotify documentation
 	// doesn't indicate that there will be).
 	if eventMetadata.Mask&unix.FAN_Q_OVERFLOW != 0 {
-		return nil, "", errors.New("event overflow")
+		return nil, "", ErrWatchInternalOverflow
 	}
 
 	// Extract the event information header and verify that the event

--- a/tools/watch_demo/watch_demo.go
+++ b/tools/watch_demo/watch_demo.go
@@ -30,14 +30,14 @@ func main() {
 	// watcher we establish as a RecursiveWatcher.
 	var watcher watching.RecursiveWatcher
 	if watching.RecursiveWatchingSupported {
-		if w, err := watching.NewRecursiveWatcher(watchRoot, nil); err != nil {
+		if w, err := watching.NewRecursiveWatcher(watchRoot); err != nil {
 			cmd.Fatal(fmt.Errorf("unable to establish recursive watch: %w", err))
 		} else {
 			watcher = w
 			fmt.Println("Watching", watchRoot, "with recursive watching")
 		}
 	} else if watching.NonRecursiveWatchingSupported {
-		if w, err := watching.NewNonRecursiveWatcher(nil); err != nil {
+		if w, err := watching.NewNonRecursiveWatcher(); err != nil {
 			cmd.Fatal(fmt.Errorf("unable to establish non-recursive watch: %w", err))
 		} else {
 			w.Watch(watchRoot)
@@ -51,11 +51,8 @@ func main() {
 	// Print events and their paths until watching has terminated.
 	for {
 		select {
-		case event := <-watcher.Events():
-			fmt.Println("Received event with", len(event), "paths")
-			for path := range event {
-				fmt.Printf("\t<%s>\n", path)
-			}
+		case path := <-watcher.Events():
+			fmt.Printf("\"%s\"\n", path)
 		case err := <-watcher.Errors():
 			cmd.Fatal(fmt.Errorf("watching failed: %w", err))
 		case <-signalTermination:


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This commit relocates watch coalescing and event filtering from watcher implementations back into the local synchronization endpoint implementation.  This is something of a "refactored revert" of the original relocation from endpoint to watchers early in the v0.14.x development cycle.  That relocation turned out to be a design mistake, or at a least hindrance, and it's actually easier to manage event coalescing with a slightly different approach that's better suited to adaptation in the face of rapid event notifications and OS-level event overflows.
