### PR TITLE
agent: restructure error reporting on handshake failure

### DIFF
--- a/pkg/mutagen/version.go
+++ b/pkg/mutagen/version.go
@@ -19,7 +19,7 @@ const (
 	// VersionTag represents a tag to be appended to the Mutagen version string.
 	// It must not contain spaces. If empty, no tag is appended to the version
 	// string.
-	VersionTag = "beta1"
+	VersionTag = "beta2"
 )
 
 // DevelopmentModeEnabled indicates that development mode is active. This is


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This PR restructures error handling on agent handshake failures.  Errors now return as much information as possible to aid in debugging.

**Which issue(s) does this pull request address (if any)?**

#351
