### PR TITLE
all: Windows improvements for v0.15.0-beta3

### DIFF
--- a/cmd/mutagen/main.go
+++ b/cmd/mutagen/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"os"
-	"runtime"
 
 	"github.com/spf13/cobra"
 
@@ -79,25 +78,9 @@ func init() {
 		generateCommand,
 	)
 
-	// HACK If we're on Windows, enable color support for command usage and
-	// error output by recursively replacing the output streams for Cobra
-	// commands.
-	if runtime.GOOS == "windows" {
-		enableColorForCommand(rootCommand)
-	}
-}
-
-// enableColorForCommand recursively enables colorized usage and error output
-// for a command and all of its child commands.
-func enableColorForCommand(command *cobra.Command) {
-	// Enable color support for the command itself.
-	command.SetOut(color.Output)
-	command.SetErr(color.Error)
-
-	// Recursively enable color support for child commands.
-	for _, c := range command.Commands() {
-		enableColorForCommand(c)
-	}
+	// Enable color output support for all commands in the hierarchy.
+	rootCommand.SetOut(color.Output)
+	rootCommand.SetErr(color.Error)
 }
 
 func main() {

--- a/pkg/mutagen/version.go
+++ b/pkg/mutagen/version.go
@@ -19,7 +19,7 @@ const (
 	// VersionTag represents a tag to be appended to the Mutagen version string.
 	// It must not contain spaces. If empty, no tag is appended to the version
 	// string.
-	VersionTag = "beta2"
+	VersionTag = "beta3"
 )
 
 // DevelopmentModeEnabled indicates that development mode is active. This is

--- a/pkg/ssh/ssh_windows.go
+++ b/pkg/ssh/ssh_windows.go
@@ -7,14 +7,13 @@ import (
 // commandSearchPaths specifies locations on Windows where we might find ssh.exe
 // and scp.exe binaries.
 var commandSearchPaths = []string{
-	// TODO: Add the PowerShell OpenSSH paths at the top of this list once
-	// there's a usable release.
 	`C:\Program Files\Git\usr\bin`,
 	`C:\Program Files (x86)\Git\usr\bin`,
 	`C:\msys32\usr\bin`,
 	`C:\msys64\usr\bin`,
 	`C:\cygwin\bin`,
 	`C:\cygwin64\bin`,
+	`C:\Windows\System32\OpenSSH`,
 }
 
 // sshCommandPathForPlatform will search for a suitable ssh command on Windows.


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This PR contains two Windows-related improvements for Mutagen v0.15.0-beta3 (which will hopefully be the last of the v0.15.0 betas).  First, it adds the official Windows OpenSSH binaries to Mutagen's search path.  Second, it simplifies the way that colorized output is enabled for Cobra commands on Windows.
