### PR TITLE
sync: fix encoding/json unmarshaling of VCS ignore mode type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.18'
+          go-version: '1.18.5'
       - name: "Install sha256sum"
         run: brew install coreutils
       - run: scripts/ci/setup_go.sh
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.18'
+          go-version: '1.18.5'
       - run: scripts/ci/setup_go.sh
       - run: scripts/ci/setup_ssh.sh
       - run: scripts/ci/setup_docker.sh
@@ -90,7 +90,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.18'
+          go-version: '1.18.5'
       - run: scripts/ci/setup_go.sh
         shell: bash
       - run: scripts/ci/setup_docker.sh
@@ -113,7 +113,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.18'
+          go-version: '1.18.5'
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
       - uses: docker/login-action@v1

--- a/images/sidecar/linux/Dockerfile
+++ b/images/sidecar/linux/Dockerfile
@@ -1,5 +1,5 @@
 # Use an Alpine-based Go builder.
-FROM golang:1.18-alpine3.15 AS builder
+FROM golang:1.18.5-alpine3.15 AS builder
 
 # Disable cgo in order to match the behavior of our release binaries (and to
 # avoid the need for gcc on certain architectures).

--- a/pkg/synchronization/core/ignore_vcs_mode.go
+++ b/pkg/synchronization/core/ignore_vcs_mode.go
@@ -46,6 +46,11 @@ func (m *IgnoreVCSMode) UnmarshalText(textBytes []byte) error {
 	return nil
 }
 
+// UnmarshalJSON implements encoding/json.Unmarshaler.UnmarshalJSON.
+func (m *IgnoreVCSMode) UnmarshalJSON(textBytes []byte) error {
+	return m.UnmarshalText(textBytes)
+}
+
 // Supported indicates whether or not a particular VCS ignore mode is a valid,
 // non-default value.
 func (m IgnoreVCSMode) Supported() bool {


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This PR fixes the unmarshaling behavior of VCS ignore mode types when using the standard library `encoding/json` package.

This PR also replaces the caret syntax that we've been using to pin Go versions with an explicit version specification.

**Which issue(s) does this pull request address (if any)?**

Fixes #358
