### PR TITLE
all: backport fixes for v0.15.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.18'
+          go-version: '1.18.5'
       - name: "Install sha256sum"
         run: brew install coreutils
       - run: scripts/ci/setup_go.sh
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.18'
+          go-version: '1.18.5'
       - run: scripts/ci/setup_go.sh
       - run: scripts/ci/setup_ssh.sh
       - run: scripts/ci/setup_docker.sh
@@ -90,7 +90,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.18'
+          go-version: '1.18.5'
       - run: scripts/ci/setup_go.sh
         shell: bash
       - run: scripts/ci/setup_docker.sh
@@ -113,7 +113,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.18'
+          go-version: '1.18.5'
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
       - uses: docker/login-action@v1

--- a/cmd/mutagen/daemon/start.go
+++ b/cmd/mutagen/daemon/start.go
@@ -6,6 +6,8 @@ import (
 	"os/exec"
 	"runtime"
 
+	"golang.org/x/sys/execabs"
+
 	"github.com/spf13/cobra"
 
 	"github.com/mutagen-io/mutagen/cmd"
@@ -31,7 +33,7 @@ func startMain(_ *cobra.Command, _ []string) error {
 	if !external.UsePathBasedLookupForDaemonStart {
 		executablePath, err = os.Executable()
 	} else {
-		executablePath, err = exec.LookPath(process.ExecutableName("mutagen", runtime.GOOS))
+		executablePath, err = execabs.LookPath(process.ExecutableName("mutagen", runtime.GOOS))
 	}
 	if err != nil {
 		return fmt.Errorf("unable to determine executable path: %w", err)

--- a/cmd/mutagen/project/flush.go
+++ b/cmd/mutagen/project/flush.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/fatih/color"
-
 	"github.com/mutagen-io/mutagen/cmd"
 	"github.com/mutagen-io/mutagen/cmd/mutagen/daemon"
 	"github.com/mutagen-io/mutagen/cmd/mutagen/sync"
@@ -121,7 +119,7 @@ func flushMain(_ *cobra.Command, _ []string) error {
 // flushCommand is the flush command.
 var flushCommand = &cobra.Command{
 	Use:          "flush",
-	Short:        "Flush project synchronization sessions " + color.YellowString("[Deprecated]"),
+	Short:        "Flush project synchronization sessions",
 	Args:         cmd.DisallowArguments,
 	RunE:         flushMain,
 	SilenceUsage: true,

--- a/cmd/mutagen/project/list.go
+++ b/cmd/mutagen/project/list.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/fatih/color"
-
 	"github.com/mutagen-io/mutagen/cmd"
 	"github.com/mutagen-io/mutagen/cmd/mutagen/daemon"
 	"github.com/mutagen-io/mutagen/cmd/mutagen/forward"
@@ -132,7 +130,7 @@ func listMain(_ *cobra.Command, _ []string) error {
 // listCommand is the list command.
 var listCommand = &cobra.Command{
 	Use:          "list",
-	Short:        "List project sessions " + color.YellowString("[Deprecated]"),
+	Short:        "List project sessions",
 	Args:         cmd.DisallowArguments,
 	RunE:         listMain,
 	SilenceUsage: true,

--- a/cmd/mutagen/project/main.go
+++ b/cmd/mutagen/project/main.go
@@ -3,8 +3,6 @@ package project
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/fatih/color"
-
 	// Explicitly import packages that need to register protocol handlers.
 	_ "github.com/mutagen-io/mutagen/pkg/forwarding/protocols/docker"
 	_ "github.com/mutagen-io/mutagen/pkg/forwarding/protocols/local"
@@ -26,7 +24,7 @@ func projectMain(command *cobra.Command, _ []string) error {
 // ProjectCommand is the project command.
 var ProjectCommand = &cobra.Command{
 	Use:          "project",
-	Short:        "Orchestrate sessions for a Mutagen project " + color.YellowString("[Deprecated]"),
+	Short:        "Orchestrate sessions for a Mutagen project [Experimental]",
 	RunE:         projectMain,
 	SilenceUsage: true,
 }

--- a/cmd/mutagen/project/pause.go
+++ b/cmd/mutagen/project/pause.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/fatih/color"
-
 	"github.com/mutagen-io/mutagen/cmd"
 	"github.com/mutagen-io/mutagen/cmd/mutagen/daemon"
 	"github.com/mutagen-io/mutagen/cmd/mutagen/forward"
@@ -149,7 +147,7 @@ func pauseMain(_ *cobra.Command, _ []string) error {
 // pauseCommand is the pause command.
 var pauseCommand = &cobra.Command{
 	Use:          "pause",
-	Short:        "Pause project sessions " + color.YellowString("[Deprecated]"),
+	Short:        "Pause project sessions",
 	Args:         cmd.DisallowArguments,
 	RunE:         pauseMain,
 	SilenceUsage: true,

--- a/cmd/mutagen/project/reset.go
+++ b/cmd/mutagen/project/reset.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/fatih/color"
-
 	"github.com/mutagen-io/mutagen/cmd"
 	"github.com/mutagen-io/mutagen/cmd/mutagen/daemon"
 	"github.com/mutagen-io/mutagen/cmd/mutagen/sync"
@@ -121,7 +119,7 @@ func resetMain(_ *cobra.Command, _ []string) error {
 // resetCommand is the reset command.
 var resetCommand = &cobra.Command{
 	Use:          "reset",
-	Short:        "Reset project synchronization sessions " + color.YellowString("[Deprecated]"),
+	Short:        "Reset project synchronization sessions",
 	Args:         cmd.DisallowArguments,
 	RunE:         resetMain,
 	SilenceUsage: true,

--- a/cmd/mutagen/project/resume.go
+++ b/cmd/mutagen/project/resume.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/fatih/color"
-
 	"github.com/mutagen-io/mutagen/cmd"
 	"github.com/mutagen-io/mutagen/cmd/mutagen/daemon"
 	"github.com/mutagen-io/mutagen/cmd/mutagen/forward"
@@ -149,7 +147,7 @@ func resumeMain(_ *cobra.Command, _ []string) error {
 // resumeCommand is the resume command.
 var resumeCommand = &cobra.Command{
 	Use:          "resume",
-	Short:        "Resume project sessions " + color.YellowString("[Deprecated]"),
+	Short:        "Resume project sessions",
 	Args:         cmd.DisallowArguments,
 	RunE:         resumeMain,
 	SilenceUsage: true,

--- a/cmd/mutagen/project/run.go
+++ b/cmd/mutagen/project/run.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/fatih/color"
-
 	"github.com/mutagen-io/mutagen/pkg/filesystem/locking"
 	"github.com/mutagen-io/mutagen/pkg/identifier"
 	"github.com/mutagen-io/mutagen/pkg/project"
@@ -121,7 +119,7 @@ func runMain(_ *cobra.Command, arguments []string) error {
 // runCommand is the run command.
 var runCommand = &cobra.Command{
 	Use:          "run <command-name>",
-	Short:        "Run a project command " + color.YellowString("[Deprecated]"),
+	Short:        "Run a project command",
 	RunE:         runMain,
 	SilenceUsage: true,
 }

--- a/cmd/mutagen/project/start.go
+++ b/cmd/mutagen/project/start.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/fatih/color"
-
 	"github.com/mutagen-io/mutagen/cmd"
 	"github.com/mutagen-io/mutagen/cmd/mutagen/daemon"
 	"github.com/mutagen-io/mutagen/cmd/mutagen/forward"
@@ -415,7 +413,7 @@ func startMain(_ *cobra.Command, _ []string) error {
 // startCommand is the start command.
 var startCommand = &cobra.Command{
 	Use:          "start",
-	Short:        "Start project sessions " + color.YellowString("[Deprecated]"),
+	Short:        "Start project sessions",
 	Args:         cmd.DisallowArguments,
 	RunE:         startMain,
 	SilenceUsage: true,

--- a/cmd/mutagen/project/terminate.go
+++ b/cmd/mutagen/project/terminate.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/fatih/color"
-
 	"github.com/mutagen-io/mutagen/cmd"
 	"github.com/mutagen-io/mutagen/cmd/mutagen/daemon"
 	"github.com/mutagen-io/mutagen/cmd/mutagen/forward"
@@ -152,7 +150,7 @@ func terminateMain(_ *cobra.Command, _ []string) error {
 // terminateCommand is the terminate command.
 var terminateCommand = &cobra.Command{
 	Use:          "terminate",
-	Short:        "Terminate project sessions " + color.YellowString("[Deprecated]"),
+	Short:        "Terminate project sessions",
 	Args:         cmd.DisallowArguments,
 	RunE:         terminateMain,
 	SilenceUsage: true,

--- a/cmd/terminal_windows.go
+++ b/cmd/terminal_windows.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"os/exec"
 
+	"golang.org/x/sys/execabs"
+
 	isatty "github.com/mattn/go-isatty"
 )
 
@@ -22,7 +24,7 @@ func HandleTerminalCompatibility() {
 
 	// Since we're running inside a mintty-based terminal, we need to relaunch
 	// using winpty, so first attempt to locate it.
-	winpty, err := exec.LookPath("winpty")
+	winpty, err := execabs.LookPath("winpty")
 	if err != nil {
 		Fatal(errors.New("running inside mintty terminal and unable to locate winpty"))
 	}

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/net v0.0.0-20220403103023-749bd193bc2b
-	golang.org/x/sys v0.0.0-20220403205710-6acee93ad0eb
+	golang.org/x/sys v0.0.0-20220808155132-1c4a2a72c664
 	golang.org/x/text v0.3.7
 	google.golang.org/grpc v1.45.0
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,8 @@ golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220403205710-6acee93ad0eb h1:PVGECzEo9Y3uOidtkHGdd347NjLtITfJFO9BxFpmRoo=
-golang.org/x/sys v0.0.0-20220403205710-6acee93ad0eb/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220808155132-1c4a2a72c664 h1:v1W7bwXHsnLLloWYTVEdvGvA7BHMeBYsPcF0GLDxIRs=
+golang.org/x/sys v0.0.0-20220808155132-1c4a2a72c664/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/images/sidecar/linux/Dockerfile
+++ b/images/sidecar/linux/Dockerfile
@@ -1,5 +1,5 @@
 # Use an Alpine-based Go builder.
-FROM golang:1.18-alpine3.15 AS builder
+FROM golang:1.18.5-alpine3.15 AS builder
 
 # Disable cgo in order to match the behavior of our release binaries (and to
 # avoid the need for gcc on certain architectures).

--- a/pkg/docker/docker_darwin.go
+++ b/pkg/docker/docker_darwin.go
@@ -1,7 +1,7 @@
 package docker
 
 import (
-	"os/exec"
+	"golang.org/x/sys/execabs"
 
 	"github.com/mutagen-io/mutagen/pkg/process"
 )
@@ -17,7 +17,7 @@ var commandSearchPaths = []string{
 func commandPathForPlatform() (string, error) {
 	// First, attempt to find the docker executable using the PATH environment
 	// variable. If that works, use that result.
-	if path, err := exec.LookPath("docker"); err == nil {
+	if path, err := execabs.LookPath("docker"); err == nil {
 		return path, nil
 	}
 

--- a/pkg/docker/docker_posix.go
+++ b/pkg/docker/docker_posix.go
@@ -3,10 +3,10 @@
 package docker
 
 import (
-	"os/exec"
+	"golang.org/x/sys/execabs"
 )
 
 // commandPathForPlatform searches for the docker command in the user's path.
 func commandPathForPlatform() (string, error) {
-	return exec.LookPath("docker")
+	return execabs.LookPath("docker")
 }

--- a/pkg/docker/docker_windows.go
+++ b/pkg/docker/docker_windows.go
@@ -1,10 +1,10 @@
 package docker
 
 import (
-	"os/exec"
+	"golang.org/x/sys/execabs"
 )
 
 // commandPathForPlatform searches for the docker command in the user's path.
 func commandPathForPlatform() (string, error) {
-	return exec.LookPath("docker")
+	return execabs.LookPath("docker")
 }

--- a/pkg/mutagen/version.go
+++ b/pkg/mutagen/version.go
@@ -15,7 +15,7 @@ const (
 	// VersionMinor represents the current minor version of Mutagen.
 	VersionMinor = 15
 	// VersionPatch represents the current patch version of Mutagen.
-	VersionPatch = 0
+	VersionPatch = 1
 	// VersionTag represents a tag to be appended to the Mutagen version string.
 	// It must not contain spaces. If empty, no tag is appended to the version
 	// string.

--- a/pkg/ssh/ssh_posix.go
+++ b/pkg/ssh/ssh_posix.go
@@ -3,15 +3,15 @@
 package ssh
 
 import (
-	"os/exec"
+	"golang.org/x/sys/execabs"
 )
 
 // sshCommandPathForPlatform searches for the ssh command in the user's path.
 func sshCommandPathForPlatform() (string, error) {
-	return exec.LookPath("ssh")
+	return execabs.LookPath("ssh")
 }
 
 // scpCommandPathForPlatform searches for the scp command in the user's path.
 func scpCommandPathForPlatform() (string, error) {
-	return exec.LookPath("scp")
+	return execabs.LookPath("scp")
 }

--- a/pkg/synchronization/core/ignore_vcs_mode.go
+++ b/pkg/synchronization/core/ignore_vcs_mode.go
@@ -46,6 +46,11 @@ func (m *IgnoreVCSMode) UnmarshalText(textBytes []byte) error {
 	return nil
 }
 
+// UnmarshalJSON implements encoding/json.Unmarshaler.UnmarshalJSON.
+func (m *IgnoreVCSMode) UnmarshalJSON(textBytes []byte) error {
+	return m.UnmarshalText(textBytes)
+}
+
 // Supported indicates whether or not a particular VCS ignore mode is a valid,
 // non-default value.
 func (m IgnoreVCSMode) Supported() bool {


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This PR backports the following changes for v0.15.1:

- Un-deprecation of projects
- Fix for JSON decoding in `IgnoreVCSMode`
- Change to explicit Go version pinning

**Which issue(s) does this pull request address (if any)?**

Updates #357
Updates #358
