### PR TITLE
agent: improve command not found detection for some POSIX shells

### DIFF
--- a/pkg/agent/transport/ssh/transport.go
+++ b/pkg/agent/transport/ssh/transport.go
@@ -198,6 +198,8 @@ func (t *sshTransport) ClassifyError(processState *os.ProcessState, errorOutput 
 		return true, false, nil
 	} else if process.IsPOSIXShellCommandNotFound(processState) {
 		return true, false, nil
+	} else if process.OutputIsPOSIXCommandNotFound(errorOutput) {
+		return true, false, nil
 	} else if process.OutputIsWindowsInvalidCommand(errorOutput) {
 		// A Windows invalid command error doesn't necessarily indicate that
 		// the agent isn't installed, but instead usually indicates that we were

--- a/pkg/process/errors.go
+++ b/pkg/process/errors.go
@@ -5,9 +5,24 @@ import (
 )
 
 const (
-	windowsInvalidCommandFragment  = "is not recognized as an internal or external command"
+	// posixCommandNotFoundFragment is a fragment of the error output returned
+	// on some POSIX shells when a command is not found. The capitalization of
+	// the word "command" is inconsistent between shells, so only part of the
+	// word is used.
+	posixCommandNotFoundFragment = "ommand not found"
+	// windowsInvalidCommandFragment is a fragment of the error output returned
+	// on Windows systems when a command is not recognized.
+	windowsInvalidCommandFragment = "is not recognized as an internal or external command"
+	// windowsCommandNotFoundFragment is a fragment of the error output returned
+	// on Windows systems when a command cannot be found.
 	windowsCommandNotFoundFragment = "The system cannot find the path specified"
 )
+
+// OutputIsPOSIXCommandNotFound returns whether or not a process' error output
+// represents a command not found error on POSIX systems.
+func OutputIsPOSIXCommandNotFound(output string) bool {
+	return strings.Contains(output, posixCommandNotFoundFragment)
+}
 
 // OutputIsWindowsInvalidCommand returns whether or not a process' error output
 // represents an invalid command error on Windows.


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

Some POSIX shells (e.g. tcsh) don't return exit codes `126`/`127` when a command isn't found or is invalid. Instead, they return an exit code of `1` and a message such as "command not found". In order to handle these shells, this commit adds a new detection heuristic for POSIX systems based on error output.

**Which issue(s) does this pull request address (if any)?**

Fixes #366
