### PR TITLE
api: always show session status

### DIFF
--- a/pkg/api/models/forwarding/session.go
+++ b/pkg/api/models/forwarding/session.go
@@ -29,6 +29,8 @@ type Session struct {
 	Labels map[string]string `json:"labels,omitempty"`
 	// Paused indicates whether or not the session is paused.
 	Paused bool `json:"paused"`
+	// Status is the session status.
+	Status forwarding.Status `json:"status"`
 	// SessionState stores state fields relevant to running sessions. It is
 	// non-nil if and only if the session is unpaused.
 	*SessionState
@@ -36,8 +38,6 @@ type Session struct {
 
 // SessionState encodes fields relevant to unpaused sessions.
 type SessionState struct {
-	// Status is the session status.
-	Status forwarding.Status `json:"status"`
 	// LastError is the last forwarding error to occur.
 	LastError string `json:"lastError,omitempty"`
 	// OpenConnections is the number of connections currently open and being
@@ -69,6 +69,7 @@ func (s *Session) loadFromInternal(state *forwarding.State) {
 	s.Name = state.Session.Name
 	s.Labels = state.Session.Labels
 	s.Paused = state.Session.Paused
+	s.Status = state.Status
 
 	// Propagate endpoint information.
 	s.Source.loadFromInternal(
@@ -90,7 +91,6 @@ func (s *Session) loadFromInternal(state *forwarding.State) {
 		s.SessionState = nil
 	} else {
 		s.SessionState = &SessionState{
-			Status:            state.Status,
 			LastError:         state.LastError,
 			OpenConnections:   state.OpenConnections,
 			TotalConnections:  state.TotalConnections,

--- a/pkg/api/models/synchronization/session.go
+++ b/pkg/api/models/synchronization/session.go
@@ -29,6 +29,8 @@ type Session struct {
 	Labels map[string]string `json:"labels,omitempty"`
 	// Paused indicates whether or not the session is paused.
 	Paused bool `json:"paused"`
+	// Status is the session status.
+	Status synchronization.Status `json:"status"`
 	// SessionState stores state fields relevant to running sessions. It is
 	// non-nil if and only if the session is unpaused.
 	*SessionState
@@ -36,8 +38,6 @@ type Session struct {
 
 // SessionState encodes fields relevant to unpaused sessions.
 type SessionState struct {
-	// Status is the session status.
-	Status synchronization.Status `json:"status"`
 	// LastError is the last synchronization error to occur.
 	LastError string `json:"lastError,omitempty"`
 	// SuccessfulCycles is the number of successful synchronization cycles to
@@ -68,6 +68,7 @@ func (s *Session) loadFromInternal(state *synchronization.State) {
 	s.Name = state.Session.Name
 	s.Labels = state.Session.Labels
 	s.Paused = state.Session.Paused
+	s.Status = state.Status
 
 	// Propagate endpoint information.
 	s.Alpha.loadFromInternal(
@@ -89,7 +90,6 @@ func (s *Session) loadFromInternal(state *synchronization.State) {
 		s.SessionState = nil
 	} else {
 		s.SessionState = &SessionState{
-			Status:            state.Status,
 			LastError:         state.LastError,
 			SuccessfulCycles:  state.SuccessfulCycles,
 			Conflicts:         exportConflicts(state.Conflicts),

--- a/pkg/forwarding/state.go
+++ b/pkg/forwarding/state.go
@@ -9,7 +9,7 @@ import (
 func (s Status) Description() string {
 	switch s {
 	case Status_Disconnected:
-		return "Waiting to connect"
+		return "Disconnected"
 	case Status_ConnectingSource:
 		return "Connecting to source"
 	case Status_ConnectingDestination:

--- a/pkg/synchronization/state.go
+++ b/pkg/synchronization/state.go
@@ -9,7 +9,7 @@ import (
 func (s Status) Description() string {
 	switch s {
 	case Status_Disconnected:
-		return "Waiting to connect"
+		return "Disconnected"
 	case Status_HaltedOnRootEmptied:
 		return "Halted due to one-sided root emptying"
 	case Status_HaltedOnRootDeletion:


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This commit modifies API session representations to always include session status, even if the session is paused. Since the zero value of Status is "disconnected", it's a reasonable interpretation of the session status when paused.
