### PR TITLE
ci: use double dot range spec for rev-list in verify_commits.sh

### DIFF
--- a/scripts/ci/verify_commits.sh
+++ b/scripts/ci/verify_commits.sh
@@ -63,7 +63,7 @@ while read commit; do
 
     # Output a separator line.
     echo
-done < <(git rev-list "${VERIFY_COMMIT_START}...${VERIFY_COMMIT_END}")
+done < <(git rev-list "${VERIFY_COMMIT_START}..${VERIFY_COMMIT_END}")
 
 # Enforce that at least one commit was verified.
 if [[ "${PERFORMED_VERIFICATION}" == "false" ]]; then


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This PR fixes the `verify_commits.sh` script to account for the fact that we want to allow PR merges into `master` that are not fully up-to-date.
