### PR TITLE
all: bump version to v0.16.0-alpha1

### DIFF
--- a/pkg/mutagen/version.go
+++ b/pkg/mutagen/version.go
@@ -19,7 +19,7 @@ const (
 	// VersionTag represents a tag to be appended to the Mutagen version string.
 	// It must not contain spaces. If empty, no tag is appended to the version
 	// string.
-	VersionTag = "dev"
+	VersionTag = "alpha1"
 )
 
 // DevelopmentModeEnabled indicates that development mode is active. This is


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This commit bumps the development version to v0.16.0-alpha1.  This release is for internal development and testing only; beta and final releases for v0.16.0 will follow shortly.
