### PR TITLE
all: minor comment, logging, error, and output tweaks for v0.16

### DIFF
--- a/pkg/api/models/synchronization/session.go
+++ b/pkg/api/models/synchronization/session.go
@@ -42,7 +42,7 @@ type SessionState struct {
 	LastError string `json:"lastError,omitempty"`
 	// SuccessfulCycles is the number of successful synchronization cycles to
 	// occur since successfully connecting to the endpoints.
-	SuccessfulCycles uint64 `json:"successfulCycles,omitempty"`
+	SuccessfulCycles uint64 `json:"successfulCycles"`
 	// Conflicts are the conflicts that identified during reconciliation. This
 	// list may be a truncated version of the full list if too many conflicts
 	// are encountered to report via the API.

--- a/pkg/forwarding/manager.go
+++ b/pkg/forwarding/manager.go
@@ -54,7 +54,7 @@ func NewManager(logger *logging.Logger) (*Manager, error) {
 		}
 		logger.Info("Loading session", id)
 		if controller, err := loadSession(logger.Sublogger(identifier.Truncated(id)), tracker, id); err != nil {
-			logger.Warnf("Failed to load session %s: %v", err)
+			logger.Warnf("Failed to load session %s: %v", id, err)
 			continue
 		} else {
 			sessions[id] = controller

--- a/pkg/forwarding/protocols/docker/protocol.go
+++ b/pkg/forwarding/protocols/docker/protocol.go
@@ -2,7 +2,6 @@ package docker
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 
@@ -86,7 +85,7 @@ func (p *protocolHandler) Connect(
 		}
 		stream = result.stream
 	case <-ctx.Done():
-		return nil, errors.New("connect operation cancelled")
+		return nil, context.Canceled
 	}
 
 	// Create the endpoint.

--- a/pkg/forwarding/protocols/local/protocol.go
+++ b/pkg/forwarding/protocols/local/protocol.go
@@ -2,7 +2,6 @@ package local
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/mutagen-io/mutagen/pkg/forwarding"
@@ -32,14 +31,6 @@ func (p *protocolHandler) Connect(
 		panic("non-forwarding URL dispatched to forwarding protocol handler")
 	} else if url.Protocol != urlpkg.Protocol_Local {
 		panic("non-local URL dispatched to local protocol handler")
-	}
-
-	// Ensure that no environment variables or parameters are specified. These
-	// are neither expected nor supported for local URLs.
-	if len(url.Environment) > 0 {
-		return nil, errors.New("local URL contains environment variables")
-	} else if len(url.Parameters) > 0 {
-		return nil, errors.New("local URL contains internal parameters")
 	}
 
 	// Parse the target specification from the URL's Path component.

--- a/pkg/forwarding/protocols/ssh/protocol.go
+++ b/pkg/forwarding/protocols/ssh/protocol.go
@@ -2,7 +2,6 @@ package ssh
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 
@@ -46,14 +45,6 @@ func (p *protocolHandler) Connect(
 		panic("non-SSH URL dispatched to SSH protocol handler")
 	}
 
-	// Ensure that no environment variables or parameters are specified. These
-	// are neither expected nor supported for SSH URLs.
-	if len(url.Environment) > 0 {
-		return nil, errors.New("SSH URL contains environment variables")
-	} else if len(url.Parameters) > 0 {
-		return nil, errors.New("SSH URL contains internal parameters")
-	}
-
 	// Parse the target specification from the URL's Path component.
 	protocol, address, err := forwardingurlpkg.Parse(url.Path)
 	if err != nil {
@@ -94,7 +85,7 @@ func (p *protocolHandler) Connect(
 		}
 		stream = result.stream
 	case <-ctx.Done():
-		return nil, errors.New("connect operation cancelled")
+		return nil, context.Canceled
 	}
 
 	// Create the endpoint.

--- a/pkg/stream/line_processor.go
+++ b/pkg/stream/line_processor.go
@@ -43,6 +43,11 @@ type LineProcessor struct {
 // Write implements io.Writer.Write.
 func (p *LineProcessor) Write(data []byte) (int, error) {
 	// Ensure that storing the data won't exceed buffer size limits.
+	// TODO: We could truncate data here if any capacity remains. A partial
+	// fragment could (in theory) contain a newline that would allow the buffer
+	// to be cleared out, though it's hard to imagine such an optimization is
+	// critical given the relatively large default maximum buffer size and the
+	// typical line size of most newline-delimited data.
 	if p.MaximumBufferSize == 0 && len(p.buffer)+len(data) > defaultLineProcessorMaximumBufferSize {
 		return 0, ErrMaximumBufferSizeExceeded
 	} else if p.MaximumBufferSize > 0 && len(p.buffer)+len(data) > p.MaximumBufferSize {

--- a/pkg/synchronization/manager.go
+++ b/pkg/synchronization/manager.go
@@ -71,7 +71,7 @@ func NewManager(logger *logging.Logger) (*Manager, error) {
 		}
 		logger.Info("Loading session", id)
 		if controller, err := loadSession(logger.Sublogger(identifier.Truncated(id)), tracker, id); err != nil {
-			logger.Warnf("Failed to load session %s: %v", err)
+			logger.Warnf("Failed to load session %s: %v", id, err)
 			continue
 		} else {
 			sessions[id] = controller

--- a/pkg/synchronization/protocols/docker/protocol.go
+++ b/pkg/synchronization/protocols/docker/protocol.go
@@ -2,7 +2,6 @@ package docker
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 
@@ -79,7 +78,7 @@ func (h *protocolHandler) Connect(
 		}
 		stream = result.stream
 	case <-ctx.Done():
-		return nil, errors.New("connect operation cancelled")
+		return nil, context.Canceled
 	}
 
 	// Create the endpoint client.

--- a/pkg/synchronization/protocols/local/protocol.go
+++ b/pkg/synchronization/protocols/local/protocol.go
@@ -2,7 +2,6 @@ package local
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/mutagen-io/mutagen/pkg/logging"
@@ -31,14 +30,6 @@ func (h *protocolHandler) Connect(
 		panic("non-synchronization URL dispatched to synchronization protocol handler")
 	} else if url.Protocol != urlpkg.Protocol_Local {
 		panic("non-local URL dispatched to local protocol handler")
-	}
-
-	// Ensure that no environment variables or parameters are specified. These
-	// are neither expected nor supported for local URLs.
-	if len(url.Environment) > 0 {
-		return nil, errors.New("local URL contains environment variables")
-	} else if len(url.Parameters) > 0 {
-		return nil, errors.New("local URL contains internal parameters")
 	}
 
 	// Create a local endpoint.

--- a/pkg/synchronization/protocols/ssh/protocol.go
+++ b/pkg/synchronization/protocols/ssh/protocol.go
@@ -2,7 +2,6 @@ package ssh
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 
@@ -45,14 +44,6 @@ func (h *protocolHandler) Connect(
 		panic("non-SSH URL dispatched to SSH protocol handler")
 	}
 
-	// Ensure that no environment variables or parameters are specified. These
-	// are neither expected nor supported for SSH URLs.
-	if len(url.Environment) > 0 {
-		return nil, errors.New("SSH URL contains environment variables")
-	} else if len(url.Parameters) > 0 {
-		return nil, errors.New("SSH URL contains internal parameters")
-	}
-
 	// Create an SSH agent transport.
 	transport, err := ssh.NewTransport(url.User, url.Host, uint16(url.Port), prompter)
 	if err != nil {
@@ -87,7 +78,7 @@ func (h *protocolHandler) Connect(
 		}
 		stream = result.stream
 	case <-ctx.Done():
-		return nil, errors.New("connect operation cancelled")
+		return nil, context.Canceled
 	}
 
 	// Create the endpoint client.


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This PR makes minor changes to logging, comments, and errors in preparation for v0.16.  Most of these changes have no visible impact to users.

The only user-visible change is that the `successfulCycles` field for synchronization sessions will now be rendered unconditionally in JSON output, even if it's `0`.