### PR TITLE
sync: use shorter inactivity periods for cache and staging housekeeping

### DIFF
--- a/pkg/api/models/synchronization/session.go
+++ b/pkg/api/models/synchronization/session.go
@@ -42,7 +42,7 @@ type SessionState struct {
 	LastError string `json:"lastError,omitempty"`
 	// SuccessfulCycles is the number of successful synchronization cycles to
 	// occur since successfully connecting to the endpoints.
-	SuccessfulCycles uint64 `json:"successfulCycles"`
+	SuccessfulCycles uint64 `json:"successfulCycles,omitempty"`
 	// Conflicts are the conflicts that identified during reconciliation. This
 	// list may be a truncated version of the full list if too many conflicts
 	// are encountered to report via the API.

--- a/pkg/housekeeping/housekeep.go
+++ b/pkg/housekeeping/housekeep.go
@@ -18,9 +18,9 @@ const (
 	// is allowed to sit on disk without being executed before being deleted.
 	maximumAgentIdlePeriod = 30 * 24 * time.Hour
 	// maximumCacheAge is the maximum allowed cache age.
-	maximumCacheAge = 30 * 24 * time.Hour
+	maximumCacheAge = 7 * 24 * time.Hour
 	// maximumStagingRootAge is the maximum allowed staging root age.
-	maximumStagingRootAge = 30 * 24 * time.Hour
+	maximumStagingRootAge = 7 * 24 * time.Hour
 )
 
 // Housekeep invokes housekeeping functions on the Mutagen data directory.


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This PR switches synchronization housekeeping to use inactivity periods of one week (instead of 30 days) when classifying session caches and staging roots as stale.

This PR also reverts an unreleased prior change to synchronization JSON output.