### PR TITLE
sync: flag non-UTF-8 filenames as problematic content

### DIFF
--- a/pkg/synchronization/core/testing_entries_test.go
+++ b/pkg/synchronization/core/testing_entries_test.go
@@ -57,6 +57,9 @@ var tP1 = &Entry{Kind: EntryKind_Problematic, Problem: "something bad happened"}
 // tP2 is an alternate problematic entry for testing.
 var tP2 = &Entry{Kind: EntryKind_Problematic, Problem: "another bad thing happened"}
 
+// tPInvalidUTF8 is a problematic entry indicating non-UTF-8 filename encoding.
+var tPInvalidUTF8 = &Entry{Kind: EntryKind_Problematic, Problem: "non-UTF-8 filename"}
+
 // tD0 is an empty directory entry for testing.
 var tD0 = &Entry{}
 


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This PR modifies scan operations to flag non-UTF-8 filenames as problematic content (with sanitized names) instead of passing them through to the content map with a "bag-of-bytes" mentality.  While we would ideally be able to treat them opaquely, doing so unfortunately leads to somewhat useless name comparisons.  Moreover, Protocol Buffers can't marshal non-UTF-8 strings.

The effect of this change should be minimal.  It shouldn't affect any cases that weren't previously affected by Protocol Buffers encoding failing.

**Which issue(s) does this pull request address (if any)?**

This addresses an issue reported on Slack by @rfay.
