### PR TITLE
sync: add missing logic for permissions mode

### DIFF
--- a/cmd/mutagen/sync/list_monitor_common.go
+++ b/cmd/mutagen/sync/list_monitor_common.go
@@ -335,7 +335,7 @@ func printSession(state *synchronization.State, mode common.SessionDisplayMode) 
 		}
 		fmt.Println("\tMaximum staging file size:", maximumStagingFileSizeDescription)
 
-		// Compute and print symlink mode.
+		// Compute and print symbolic link mode.
 		symbolicLinkModeDescription := configuration.SymbolicLinkMode.Description()
 		if configuration.SymbolicLinkMode.IsDefault() {
 			defaultSymbolicLinkMode := state.Session.Version.DefaultSymbolicLinkMode()
@@ -369,6 +369,14 @@ func printSession(state *synchronization.State, mode common.SessionDisplayMode) 
 		} else {
 			fmt.Println("\tIgnores: None")
 		}
+
+		// Compute and print permissions mode.
+		permissionsModeDescription := configuration.PermissionsMode.Description()
+		if configuration.PermissionsMode.IsDefault() {
+			defaultPermissionsMode := state.Session.Version.DefaultPermissionsMode()
+			permissionsModeDescription += fmt.Sprintf(" (%s)", defaultPermissionsMode.Description())
+		}
+		fmt.Println("\tPermissions mode:", permissionsModeDescription)
 	}
 
 	// Compute and print alpha-specific configuration.

--- a/pkg/api/models/synchronization/configuration_test.go
+++ b/pkg/api/models/synchronization/configuration_test.go
@@ -33,6 +33,7 @@ ignore:
   vcs: true
 
 permissions:
+  mode: "portable"
   defaultFileMode: 644
   defaultDirectoryMode: 0755
   defaultOwner: "george"
@@ -58,6 +59,7 @@ var expectedConfiguration = &synchronization.Configuration{
 		"!ignore/this/that",
 	},
 	IgnoreVCSMode:        core.IgnoreVCSMode_IgnoreVCSModeIgnore,
+	PermissionsMode:      core.PermissionsMode_PermissionsModePortable,
 	DefaultFileMode:      0644,
 	DefaultDirectoryMode: 0755,
 	DefaultOwner:         "george",
@@ -130,6 +132,9 @@ func TestLoadConfiguration(t *testing.T) {
 	}
 	if configuration.IgnoreVCSMode != expectedConfiguration.IgnoreVCSMode {
 		t.Error("ignore VCS mode mismatch:", configuration.IgnoreVCSMode, "!=", expectedConfiguration.IgnoreVCSMode)
+	}
+	if configuration.PermissionsMode != expectedConfiguration.PermissionsMode {
+		t.Errorf("permissions mode mismatch: %o != %o", configuration.PermissionsMode, expectedConfiguration.PermissionsMode)
 	}
 	if configuration.DefaultFileMode != expectedConfiguration.DefaultFileMode {
 		t.Errorf("default file mode mismatch: %o != %o", configuration.DefaultFileMode, expectedConfiguration.DefaultFileMode)

--- a/pkg/mutagen/version.go
+++ b/pkg/mutagen/version.go
@@ -19,7 +19,7 @@ const (
 	// VersionTag represents a tag to be appended to the Mutagen version string.
 	// It must not contain spaces. If empty, no tag is appended to the version
 	// string.
-	VersionTag = "alpha1"
+	VersionTag = "alpha2"
 )
 
 // DevelopmentModeEnabled indicates that development mode is active. This is

--- a/pkg/mutagen/version.go
+++ b/pkg/mutagen/version.go
@@ -19,7 +19,7 @@ const (
 	// VersionTag represents a tag to be appended to the Mutagen version string.
 	// It must not contain spaces. If empty, no tag is appended to the version
 	// string.
-	VersionTag = "alpha2"
+	VersionTag = "alpha3"
 )
 
 // DevelopmentModeEnabled indicates that development mode is active. This is

--- a/pkg/synchronization/configuration.go
+++ b/pkg/synchronization/configuration.go
@@ -189,6 +189,7 @@ func (c *Configuration) Equal(other *Configuration) bool {
 		comparison.StringSlicesEqual(c.DefaultIgnores, other.DefaultIgnores) &&
 		comparison.StringSlicesEqual(c.Ignores, other.Ignores) &&
 		c.IgnoreVCSMode == other.IgnoreVCSMode &&
+		c.PermissionsMode == other.PermissionsMode &&
 		c.DefaultFileMode == other.DefaultFileMode &&
 		c.DefaultDirectoryMode == other.DefaultDirectoryMode &&
 		c.DefaultOwner == other.DefaultOwner &&
@@ -279,6 +280,13 @@ func MergeConfigurations(lower, higher *Configuration) *Configuration {
 		result.IgnoreVCSMode = higher.IgnoreVCSMode
 	} else {
 		result.IgnoreVCSMode = lower.IgnoreVCSMode
+	}
+
+	// Merge permissions mode.
+	if !higher.PermissionsMode.IsDefault() {
+		result.PermissionsMode = higher.PermissionsMode
+	} else {
+		result.PermissionsMode = lower.PermissionsMode
 	}
 
 	// Merge default file mode.


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This PR adds a few bits of missing logic for the new permissions mode functionality.  It also bumps the version to v0.16.0-alpha3.
