### PR TITLE
sync: wire permissions mode into the combined CLI configuration

### DIFF
--- a/cmd/mutagen/sync/create.go
+++ b/cmd/mutagen/sync/create.go
@@ -414,6 +414,7 @@ func createMain(_ *cobra.Command, arguments []string) error {
 		WatchPollingInterval:   createConfiguration.watchPollingInterval,
 		Ignores:                createConfiguration.ignores,
 		IgnoreVCSMode:          ignoreVCSMode,
+		PermissionsMode:        permissionsMode,
 		DefaultFileMode:        uint32(defaultFileMode),
 		DefaultDirectoryMode:   uint32(defaultDirectoryMode),
 		DefaultOwner:           createConfiguration.defaultOwner,


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This PR adds what is (hopefully) the last of the CLI configuration wiring for the new permissions mode option. 🤯 
