### PR TITLE
all: v0.15.3 backports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18.5'
+          go-version: '1.18.6'
       - name: "Install sha256sum"
         run: brew install coreutils
       - run: scripts/ci/setup_go.sh
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18.5'
+          go-version: '1.18.6'
       - run: scripts/ci/setup_go.sh
       - run: scripts/ci/setup_ssh.sh
       - run: scripts/ci/setup_docker.sh
@@ -90,7 +90,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18.5'
+          go-version: '1.18.6'
       - run: scripts/ci/setup_go.sh
         shell: bash
       - run: scripts/ci/setup_docker.sh
@@ -113,7 +113,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18.5'
+          go-version: '1.18.6'
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
       - uses: docker/login-action@v1

--- a/images/sidecar/linux/Dockerfile
+++ b/images/sidecar/linux/Dockerfile
@@ -1,5 +1,5 @@
 # Use an Alpine-based Go builder.
-FROM golang:1.18.5-alpine3.15 AS builder
+FROM golang:1.18.6-alpine3.16 AS builder
 
 # Disable cgo in order to match the behavior of our release binaries (and to
 # avoid the need for gcc on certain architectures).
@@ -21,7 +21,7 @@ RUN ["go", "build", "-o", "mutagen-agent-enhanced", "-tags", "sspl,fanotify", ".
 
 
 # Switch to a vanilla Alpine base for the final image.
-FROM alpine:3.15 AS base
+FROM alpine:3.16 AS base
 
 # Copy the sidecar entry point from the builder.
 COPY --from=builder ["/mutagen/mutagen-sidecar", "/usr/bin/mutagen-sidecar"]

--- a/pkg/mutagen/version.go
+++ b/pkg/mutagen/version.go
@@ -15,7 +15,7 @@ const (
 	// VersionMinor represents the current minor version of Mutagen.
 	VersionMinor = 15
 	// VersionPatch represents the current patch version of Mutagen.
-	VersionPatch = 2
+	VersionPatch = 3
 	// VersionTag represents a tag to be appended to the Mutagen version string.
 	// It must not contain spaces. If empty, no tag is appended to the version
 	// string.

--- a/pkg/synchronization/core/scan.go
+++ b/pkg/synchronization/core/scan.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"unicode/utf8"
 
 	"golang.org/x/text/unicode/norm"
 
@@ -387,6 +388,22 @@ func (s *scanner) directory(
 		// recording these files, even as untracked entries, because we know
 		// that they're ephemeral.
 		if strings.HasPrefix(contentName, filesystem.TemporaryNamePrefix) {
+			continue
+		}
+
+		// If the filename is not valid UTF-8, then flag it as problematic
+		// content. This is important for both (a) enforcing that comparisons
+		// are performed using a common encoding and (b) allowing the name to be
+		// encoded with Protocol Buffers (which enforces that strings are UTF-8
+		// encoded when marshaling). Since the file name isn't valid for storing
+		// in the content map, we'll replace all unknown byte sequences with a
+		// replacement character and store the entry with a (hopefully)
+		// non-coliding derivative name.
+		if !utf8.ValidString(contentName) {
+			contents[strings.ToValidUTF8(contentName, "�")+" (non-UTF-8)"] = &Entry{
+				Kind:    EntryKind_Problematic,
+				Problem: "non-UTF-8 filename",
+			}
 			continue
 		}
 

--- a/pkg/synchronization/core/testing_entries_test.go
+++ b/pkg/synchronization/core/testing_entries_test.go
@@ -57,6 +57,9 @@ var tP1 = &Entry{Kind: EntryKind_Problematic, Problem: "something bad happened"}
 // tP2 is an alternate problematic entry for testing.
 var tP2 = &Entry{Kind: EntryKind_Problematic, Problem: "another bad thing happened"}
 
+// tPInvalidUTF8 is a problematic entry indicating non-UTF-8 filename encoding.
+var tPInvalidUTF8 = &Entry{Kind: EntryKind_Problematic, Problem: "non-UTF-8 filename"}
+
 // tD0 is an empty directory entry for testing.
 var tD0 = &Entry{}
 


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This PR backports selective fixes for the v0.15.3 release, including:

- bcea8e7 and 8864b22

**Which issue(s) does this pull request address (if any)?**

This PR addresses a behavioral issue with non-Unicode filenames reported by @rfay on Slack.
