### PR TITLE
sync: fix accelerated scanning corner case for fanotify

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.19.*'
+          go-version: '1.19.1'
       - name: "Install sha256sum"
         run: brew install coreutils
       - run: scripts/ci/setup_go.sh
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.19.*'
+          go-version: '1.19.1'
       - run: scripts/ci/setup_go.sh
       - run: scripts/ci/setup_ssh.sh
       - run: scripts/ci/setup_docker.sh
@@ -90,7 +90,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.19.*'
+          go-version: '1.19.1'
       - run: scripts/ci/setup_go.sh
         shell: bash
       - run: scripts/ci/setup_docker.sh
@@ -113,7 +113,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.19.*'
+          go-version: '1.19.1'
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
       - uses: docker/login-action@v1

--- a/images/sidecar/linux/Dockerfile
+++ b/images/sidecar/linux/Dockerfile
@@ -1,5 +1,5 @@
 # Use an Alpine-based Go builder.
-FROM golang:1.19-alpine3.16 AS builder
+FROM golang:1.19.1-alpine3.16 AS builder
 
 # Disable cgo in order to match the behavior of our release binaries (and to
 # avoid the need for gcc on certain architectures).

--- a/pkg/mutagen/version.go
+++ b/pkg/mutagen/version.go
@@ -19,7 +19,7 @@ const (
 	// VersionTag represents a tag to be appended to the Mutagen version string.
 	// It must not contain spaces. If empty, no tag is appended to the version
 	// string.
-	VersionTag = "beta1"
+	VersionTag = "beta2"
 )
 
 // DevelopmentModeEnabled indicates that development mode is active. This is

--- a/pkg/synchronization/core/scan.go
+++ b/pkg/synchronization/core/scan.go
@@ -474,8 +474,23 @@ func (s *scanner) directory(
 		// directly. In this case, we'll want to walk down the entry and
 		// propagate the corresponding ignore and digest cache entries that
 		// we're going to avoid generating.
+		//
+		// On Linux, there's one additional heuristic used here: if the parent
+		// path is marked as dirty, then we also consider this path dirty. That
+		// makes accelerated scanning slightly less efficient on Linux, but it's
+		// a necessity because fanotify only reports the parent path if a file
+		// or directory is created, deleted, or renamed into place. This becomes
+		// a problem in the case where a directory is deleted and then another
+		// directory with a duplicate name is renamed into its place. The only
+		// path reported in that scenario will be the parent path of those
+		// directories, meaning that no changes will be detected for the new
+		// child. FSEvents and ReadDirectoryChangesW don't have this problem.
 		if contentBaseline != nil {
-			if _, contentDirty := s.dirtyPaths[contentPath]; !contentDirty {
+			contentDirty := s.dirtyPaths[contentPath]
+			if runtime.GOOS == "linux" && !contentDirty {
+				contentDirty = s.dirtyPaths[path]
+			}
+			if !contentDirty {
 				contents[contentName] = contentBaseline
 				var missingCacheEntries bool
 				contentBaseline.walk(contentPath, func(path string, entry *Entry) {


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This pull request fixes a corner case in accelerated scanning with `fanotify`.  Specifically, it fixes the case where an empty directory is deleted and a directory with the same name is quickly renamed into its place with different contents.  This case is problematic for `fanotify` since the API only reports the parent directory path for these types of operations.  This also occurs with files or symbolic links, but we always explicitly recheck those since we pay for their metadata anyway.

To fix this corner case, we use a simple additional heuristic on Linux: we consider directories to be "dirty" if they are either explicitly marked as dirty or if their immediate parent is marked as dirty.  This does have some minor performance impact, but the benefits of accelerated scanning in this case are still significant.

To be clear: this only affects accelerated scanning and only when using `fanotify`.  This issue does not exist with the normal Linux filesystem polling and watching.

An alternative fix would be to store modification times for directories in the cache, and that may prove worthwhile in the future, though it would add to the cache size and complexity.  The cache currently has the benefit that it only contains file entries; directories would make cache contents heterogeneous and that might need to be accounted for when propagating entries in accelerated scanning.  This would also likely be slower.

**Which issue(s) does this pull request address (if any)?**

None have been reported; this was only observed in stress-testing the `fanotify` watching with Composer installs (which seem to use this directory delete/rename pattern).  This likely won't have been seen in the wild since `fanotify` is relatively new and currently only used in Mutagen Compose, however it's still probably worth backporting to v0.15.x.
