### PR TITLE
ci: disable Docker integration tests on 386

### DIFF
--- a/scripts/ci/test_386.sh
+++ b/scripts/ci/test_386.sh
@@ -6,6 +6,9 @@ set -e
 # Load test parameters.
 source scripts/ci/test_parameters.sh
 
+# Disable Docker tests for 386.
+export MUTAGEN_TEST_DOCKER="false"
+
 # Perform a local-only build so that we have an agent bundle for testing.
 GOARCH=386 go run scripts/build.go --mode=local
 


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This PR disables Docker integration tests for the 386 architecture.  GitHub has switched their runners from Docker EE to Docker CE and they are no longer shipping 386 Docker binaries, at least on Windows (and likely other platforms soon).
