### PR TITLE
all: bump version to v0.16.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
   macos:
     name: macOS
     runs-on: macos-11
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2

--- a/pkg/mutagen/version.go
+++ b/pkg/mutagen/version.go
@@ -19,7 +19,7 @@ const (
 	// VersionTag represents a tag to be appended to the Mutagen version string.
 	// It must not contain spaces. If empty, no tag is appended to the version
 	// string.
-	VersionTag = "rc1"
+	VersionTag = ""
 )
 
 // DevelopmentModeEnabled indicates that development mode is active. This is


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This PR bumps the version to v0.16.0.  There are no changes from v0.16.0-rc1.
