### PR TITLE
deps: update to Go 1.19.3 (backport)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.19.2'
+          go-version: '1.19.3'
       - name: "Install sha256sum"
         run: brew install coreutils
       - run: scripts/ci/setup_go.sh
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.19.2'
+          go-version: '1.19.3'
       - run: scripts/ci/setup_go.sh
       - run: scripts/ci/setup_ssh.sh
       - run: scripts/ci/setup_docker.sh
@@ -90,7 +90,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.19.2'
+          go-version: '1.19.3'
       - run: scripts/ci/setup_go.sh
         shell: bash
       - run: scripts/ci/setup_docker.sh
@@ -113,7 +113,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.19.2'
+          go-version: '1.19.3'
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
       - uses: docker/login-action@v1

--- a/images/sidecar/linux/Dockerfile
+++ b/images/sidecar/linux/Dockerfile
@@ -1,5 +1,5 @@
 # Use an Alpine-based Go builder.
-FROM golang:1.19.2-alpine3.16 AS builder
+FROM golang:1.19.3-alpine3.16 AS builder
 
 # Disable cgo in order to match the behavior of our release binaries (and to
 # avoid the need for gcc on certain architectures).

--- a/pkg/mutagen/version.go
+++ b/pkg/mutagen/version.go
@@ -15,7 +15,7 @@ const (
 	// VersionMinor represents the current minor version of Mutagen.
 	VersionMinor = 16
 	// VersionPatch represents the current patch version of Mutagen.
-	VersionPatch = 0
+	VersionPatch = 1
 	// VersionTag represents a tag to be appended to the Mutagen version string.
 	// It must not contain spaces. If empty, no tag is appended to the version
 	// string.


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This PR backports the update to Go 1.19.3.
