### PR TITLE
watch: allow internal inotify watcher to drop events

### DIFF
--- a/pkg/filesystem/watching/internal/third_party/notify/watcher_inotify.go
+++ b/pkg/filesystem/watching/internal/third_party/notify/watcher_inotify.go
@@ -1,6 +1,6 @@
 // Subset of https://github.com/rjeczalik/notify extracted and modified to
-// expose watcher functionality directly. Originally extracted from the
-// following revision:
+// expose watcher functionality directly. This file has also been modified to
+// allow for dropped events. Originally extracted from the following revision:
 // https://github.com/rjeczalik/notify/tree/e2a77dcc14cf6732bfa4c361554f27dc696d5d79
 //
 // The original code license:
@@ -279,7 +279,10 @@ func (i *inotify) send(esch <-chan []*event) {
 	for es := range esch {
 		for _, e := range i.transform(es) {
 			if e != nil {
-				i.c <- e
+				select {
+				case i.c <- e:
+				default:
+				}
 			}
 		}
 	}

--- a/pkg/mutagen/version.go
+++ b/pkg/mutagen/version.go
@@ -13,13 +13,13 @@ const (
 	// VersionMajor represents the current major version of Mutagen.
 	VersionMajor = 0
 	// VersionMinor represents the current minor version of Mutagen.
-	VersionMinor = 16
+	VersionMinor = 17
 	// VersionPatch represents the current patch version of Mutagen.
 	VersionPatch = 0
 	// VersionTag represents a tag to be appended to the Mutagen version string.
 	// It must not contain spaces. If empty, no tag is appended to the version
 	// string.
-	VersionTag = ""
+	VersionTag = "dev"
 )
 
 // DevelopmentModeEnabled indicates that development mode is active. This is


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This PR modifies the vendored inotify watcher implementation to allow for event dropping.  At the moment, no events are dropped, which can block the watcher's run loop from signaling termination.  Since our non-recursive watching is opportunistic/best-effort anyway (i.e. only meant to reduce sync cycle latency, not responsible for tracking changes), there's no harm in this change.  Without this, the watcher can block endpoint shutdown indefinitely if the event queue is full.

Eventually, we'll probably just want to write our own inotify implementation. Our needs are simpler than those of the code that we've vendored, which also no longer appears to be maintained upstream.

**Which issue(s) does this pull request address (if any)?**

No issue in particular, though recent Linux/386 builds have been failing intermittently, probably due to scheduler changes in Go 1.19.
