### PR TITLE
all: v0.16.2 backports

### DIFF
--- a/pkg/filesystem/resources.go
+++ b/pkg/filesystem/resources.go
@@ -28,6 +28,8 @@ func LibexecPath() (string, error) {
 	} else if metadata.Mode()&os.ModeSymlink != 0 {
 		if target, err := os.Readlink(executablePath); err != nil {
 			return "", fmt.Errorf("unable to read executable symbolic link target: %w", err)
+		} else if filepath.IsAbs(target) {
+			executablePath = target
 		} else if resolved, err := filepath.Abs(filepath.Join(filepath.Dir(executablePath), target)); err != nil {
 			return "", fmt.Errorf("unable to resolve executable symbolic link target: %w", err)
 		} else {

--- a/pkg/filesystem/watching/internal/third_party/notify/watcher_inotify.go
+++ b/pkg/filesystem/watching/internal/third_party/notify/watcher_inotify.go
@@ -1,6 +1,6 @@
 // Subset of https://github.com/rjeczalik/notify extracted and modified to
-// expose watcher functionality directly. Originally extracted from the
-// following revision:
+// expose watcher functionality directly. This file has also been modified to
+// allow for dropped events. Originally extracted from the following revision:
 // https://github.com/rjeczalik/notify/tree/e2a77dcc14cf6732bfa4c361554f27dc696d5d79
 //
 // The original code license:
@@ -279,7 +279,10 @@ func (i *inotify) send(esch <-chan []*event) {
 	for es := range esch {
 		for _, e := range i.transform(es) {
 			if e != nil {
-				i.c <- e
+				select {
+				case i.c <- e:
+				default:
+				}
 			}
 		}
 	}

--- a/pkg/mutagen/version.go
+++ b/pkg/mutagen/version.go
@@ -15,7 +15,7 @@ const (
 	// VersionMinor represents the current minor version of Mutagen.
 	VersionMinor = 16
 	// VersionPatch represents the current patch version of Mutagen.
-	VersionPatch = 1
+	VersionPatch = 2
 	// VersionTag represents a tag to be appended to the Mutagen version string.
 	// It must not contain spaces. If empty, no tag is appended to the version
 	// string.


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This PR backports two fixes for the v0.16.x release branch, in particular:

- A fix for resolution of absolute symlinks when identifying `libexec` paths (thanks to @dj95)
- A fix for inotify event channel blocking on endpoint shutdown

**Which issue(s) does this pull request address (if any)?**

Backports the fix for #400