### PR TITLE
cmd: allow multiple default configuration files to be specified

### DIFF
--- a/cmd/mutagen/forward/create.go
+++ b/cmd/mutagen/forward/create.go
@@ -150,11 +150,11 @@ func createMain(_ *cobra.Command, arguments []string) error {
 		}
 	}
 
-	// If a configuration file has been specified, then load it and merge it
-	// into our cumulative configuration.
-	if createConfiguration.configurationFile != "" {
-		if c, err := loadAndValidateGlobalForwardingConfiguration(createConfiguration.configurationFile); err != nil {
-			return fmt.Errorf("unable to load configuration file: %w", err)
+	// If additional default configuration files have been specified, then load
+	// them and merge them into the cumulative configuration.
+	for _, configurationFile := range createConfiguration.configurationFiles {
+		if c, err := loadAndValidateGlobalForwardingConfiguration(configurationFile); err != nil {
+			return fmt.Errorf("unable to load configuration file (%s): %w", configurationFile, err)
 		} else {
 			configuration = forwarding.MergeConfigurations(configuration, c)
 		}
@@ -315,9 +315,9 @@ var createConfiguration struct {
 	// noGlobalConfiguration specifies whether or not the global configuration
 	// file should be ignored.
 	noGlobalConfiguration bool
-	// configurationFile specifies a file from which to load configuration. It
-	// should be a path relative to the working directory.
-	configurationFile string
+	// configurationFiles stores paths of additional files from which to load
+	// default configuration.
+	configurationFiles []string
 	// socketOverwriteMode specifies the socket overwrite mode to use for the
 	// session.
 	socketOverwriteMode string
@@ -385,7 +385,7 @@ func init() {
 
 	// Wire up general configuration flags.
 	flags.BoolVar(&createConfiguration.noGlobalConfiguration, "no-global-configuration", false, "Ignore the global configuration file")
-	flags.StringVarP(&createConfiguration.configurationFile, "configuration-file", "c", "", "Specify a file from which to load additional default configuration")
+	flags.StringSliceVarP(&createConfiguration.configurationFiles, "configuration-file", "c", nil, "Specify additional files from which to load (and merge) default configuration parameters")
 
 	// Wire up socket flags.
 	flags.StringVar(&createConfiguration.socketOverwriteMode, "socket-overwrite-mode", "", "Specify socket overwrite mode (leave|overwrite)")

--- a/cmd/mutagen/sync/create.go
+++ b/cmd/mutagen/sync/create.go
@@ -154,11 +154,11 @@ func createMain(_ *cobra.Command, arguments []string) error {
 		}
 	}
 
-	// If a configuration file has been specified, then load it and merge it
-	// into our cumulative configuration.
-	if createConfiguration.configurationFile != "" {
-		if c, err := loadAndValidateGlobalSynchronizationConfiguration(createConfiguration.configurationFile); err != nil {
-			return fmt.Errorf("unable to load configuration file: %w", err)
+	// If additional default configuration files have been specified, then load
+	// them and merge them into the cumulative configuration.
+	for _, configurationFile := range createConfiguration.configurationFiles {
+		if c, err := loadAndValidateGlobalSynchronizationConfiguration(configurationFile); err != nil {
+			return fmt.Errorf("unable to load configuration file (%s): %w", configurationFile, err)
 		} else {
 			configuration = synchronization.MergeConfigurations(configuration, c)
 		}
@@ -495,9 +495,9 @@ var createConfiguration struct {
 	// noGlobalConfiguration specifies whether or not the global configuration
 	// file should be ignored.
 	noGlobalConfiguration bool
-	// configurationFile specifies a file from which to load configuration. It
-	// should be a path relative to the working directory.
-	configurationFile string
+	// configurationFiles stores paths of additional files from which to load
+	// default configuration.
+	configurationFiles []string
 	// synchronizationMode specifies the synchronization mode for the session.
 	synchronizationMode string
 	// maximumEntryCount specifies the maximum number of filesystem entries that
@@ -635,7 +635,7 @@ func init() {
 
 	// Wire up general configuration flags.
 	flags.BoolVar(&createConfiguration.noGlobalConfiguration, "no-global-configuration", false, "Ignore the global configuration file")
-	flags.StringVarP(&createConfiguration.configurationFile, "configuration-file", "c", "", "Specify a file from which to load additional default configuration")
+	flags.StringSliceVarP(&createConfiguration.configurationFiles, "configuration-file", "c", nil, "Specify additional files from which to load (and merge) default configuration parameters")
 
 	// Wire up synchronization flags.
 	flags.StringVarP(&createConfiguration.synchronizationMode, "sync-mode", "m", "", "Specify synchronization mode (two-way-safe|two-way-resolved|one-way-safe|one-way-replica)")


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This commit modifies the create commands (for both synchronization and forwarding) to accept multiple specifications of the -c/--configuration-file flag, merging later specifications on top of earlier ones.

**Which issue(s) does this pull request address (if any)?**

#406
