### PR TITLE
all: switch to faster gzip implementation for agent bundle handling

### DIFF
--- a/pkg/agent/bundle.go
+++ b/pkg/agent/bundle.go
@@ -2,13 +2,14 @@ package agent
 
 import (
 	"archive/tar"
-	"compress/gzip"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"runtime"
+
+	"github.com/klauspost/compress/gzip"
 
 	"github.com/mutagen-io/mutagen/pkg/filesystem"
 	"github.com/mutagen-io/mutagen/pkg/mutagen"

--- a/scripts/build.go
+++ b/scripts/build.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"archive/tar"
-	"compress/gzip"
 	"errors"
 	"fmt"
 	"io"
@@ -15,6 +14,8 @@ import (
 	"time"
 
 	"github.com/spf13/pflag"
+
+	"github.com/klauspost/compress/gzip"
 
 	"github.com/mutagen-io/mutagen/cmd"
 


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This PR switches the build script and agent extraction code to use the faster gzip implementation included in the new compress package that we added during staging optimization.
