### PR TITLE
all: add mechanism to detect extension environment

### DIFF
--- a/pkg/extension/doc.go
+++ b/pkg/extension/doc.go
@@ -1,0 +1,3 @@
+// Package extension provides supporting infrastructure for the Mutagen
+// Extension for Docker Desktop.
+package extension

--- a/pkg/extension/environment.go
+++ b/pkg/extension/environment.go
@@ -1,0 +1,22 @@
+package extension
+
+import (
+	"os"
+	"sync"
+)
+
+// environmentIsExtension is the cached result of the extension environment
+// check.
+var environmentIsExtension bool
+
+// checkEnvironmentOnce gates access to environmentIsExtension.
+var checkEnvironmentOnce sync.Once
+
+// EnvironmentIsExtension returns true if the current operating environment is
+// the Mutagen Extension for Docker Desktop service container.
+func EnvironmentIsExtension() bool {
+	checkEnvironmentOnce.Do(func() {
+		environmentIsExtension = os.Getenv("MUTAGEN_EXTENSION") == "1"
+	})
+	return environmentIsExtension
+}


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This PR adds a mechanism to tweak behaviors when running in the Mutagen Extension for Docker Desktop.

The primary tweak required here is a change to URL validation behavior, but others may be necessary in the future.
