### PR TITLE
all: backport mechanism to detect extension environment

### DIFF
--- a/pkg/extension/doc.go
+++ b/pkg/extension/doc.go
@@ -1,0 +1,3 @@
+// Package extension provides supporting infrastructure for the Mutagen
+// Extension for Docker Desktop.
+package extension

--- a/pkg/extension/environment.go
+++ b/pkg/extension/environment.go
@@ -1,0 +1,22 @@
+package extension
+
+import (
+	"os"
+	"sync"
+)
+
+// environmentIsExtension is the cached result of the extension environment
+// check.
+var environmentIsExtension bool
+
+// checkEnvironmentOnce gates access to environmentIsExtension.
+var checkEnvironmentOnce sync.Once
+
+// EnvironmentIsExtension returns true if the current operating environment is
+// the Mutagen Extension for Docker Desktop service container.
+func EnvironmentIsExtension() bool {
+	checkEnvironmentOnce.Do(func() {
+		environmentIsExtension = os.Getenv("MUTAGEN_EXTENSION") == "1"
+	})
+	return environmentIsExtension
+}


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This PR backports the #420 to the v0.16.x release branch.

This isn't critical at the moment because this patch is only for the Docker Desktop extension, but it's best to have it ready to go if/when v0.16.5 ships.
