### PR TITLE
deps: update to Go 1.20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.19.5'
+          go-version: '1.20.0'
       - name: "Install sha256sum"
         run: brew install coreutils
       - run: scripts/ci/setup_go.sh
@@ -70,11 +70,14 @@ jobs:
     name: Linux
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      matrix:
+        goversion: ['1.19.5', '1.20.0']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.19.5'
+          go-version: ${{ matrix.goversion }}
       - run: scripts/ci/setup_go.sh
       - run: scripts/ci/setup_ssh.sh
       - run: scripts/ci/setup_docker.sh
@@ -90,7 +93,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.19.5'
+          go-version: '1.20.0'
       - run: scripts/ci/setup_go.sh
         shell: bash
       - run: scripts/ci/setup_docker.sh
@@ -113,7 +116,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.19.5'
+          go-version: '1.20.0'
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
       - uses: docker/login-action@v1

--- a/images/sidecar/linux/Dockerfile
+++ b/images/sidecar/linux/Dockerfile
@@ -21,7 +21,7 @@ RUN ["go", "build", "-o", "mutagen-agent-mit", "./cmd/mutagen-agent"]
 
 
 # Switch to a vanilla Alpine base for the final image.
-FROM alpine:3.16 AS base
+FROM alpine:3.17 AS base
 
 # Copy the sidecar entry point from the builder.
 COPY --from=builder ["/mutagen/mutagen-sidecar", "/usr/bin/mutagen-sidecar"]

--- a/images/sidecar/linux/Dockerfile
+++ b/images/sidecar/linux/Dockerfile
@@ -1,5 +1,5 @@
 # Use an Alpine-based Go builder.
-FROM golang:1.19.5-alpine3.17 AS builder
+FROM golang:1.20.0-alpine3.17 AS builder
 
 # Disable cgo in order to match the behavior of our release binaries (and to
 # avoid the need for gcc on certain architectures).


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This PR updates the build toolchain to Go 1.20.  It also updates the sidecar base image to Alpine 3.17, which should have been done earlier, at least for the development branch.

Unlike previous toolchain updates, we're going to continue supporting and testing the previous Go version.  This is a bit of an experiment, but it shouldn't present any significant difficulty.  The benefits (namely portability and flexibility) should outweigh the costs (i.e. waiting to adopt new APIs or managing their adoption through build tags).
