### PR TITLE
all: prepare for v0.16.5 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.19.5'
+          go-version: '1.19.6'
       - name: "Install sha256sum"
         run: brew install coreutils
       - run: scripts/ci/setup_go.sh
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.19.5'
+          go-version: '1.19.6'
       - run: scripts/ci/setup_go.sh
       - run: scripts/ci/setup_ssh.sh
       - run: scripts/ci/setup_docker.sh
@@ -90,7 +90,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.19.5'
+          go-version: '1.19.6'
       - run: scripts/ci/setup_go.sh
         shell: bash
       - run: scripts/ci/setup_docker.sh
@@ -113,7 +113,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.19.5'
+          go-version: '1.19.6'
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
       - uses: docker/login-action@v1

--- a/images/sidecar/linux/Dockerfile
+++ b/images/sidecar/linux/Dockerfile
@@ -1,5 +1,5 @@
 # Use an Alpine-based Go builder.
-FROM golang:1.19.5-alpine3.17 AS builder
+FROM golang:1.19.6-alpine3.17 AS builder
 
 # Disable cgo in order to match the behavior of our release binaries (and to
 # avoid the need for gcc on certain architectures).

--- a/images/sidecar/linux/Dockerfile
+++ b/images/sidecar/linux/Dockerfile
@@ -21,7 +21,7 @@ RUN ["go", "build", "-o", "mutagen-agent-enhanced", "-tags", "sspl,fanotify", ".
 
 
 # Switch to a vanilla Alpine base for the final image.
-FROM alpine:3.16 AS base
+FROM alpine:3.17 AS base
 
 # Copy the sidecar entry point from the builder.
 COPY --from=builder ["/mutagen/mutagen-sidecar", "/usr/bin/mutagen-sidecar"]

--- a/pkg/mutagen/version.go
+++ b/pkg/mutagen/version.go
@@ -15,7 +15,7 @@ const (
 	// VersionMinor represents the current minor version of Mutagen.
 	VersionMinor = 16
 	// VersionPatch represents the current patch version of Mutagen.
-	VersionPatch = 4
+	VersionPatch = 5
 	// VersionTag represents a tag to be appended to the Mutagen version string.
 	// It must not contain spaces. If empty, no tag is appended to the version
 	// string.


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This PR updates Go to 1.19.6 and makes a corresponding update to the sidecar's Alpine base image to match the build image Alpine version.

**Which issue(s) does this pull request address (if any)?**

There are [a number of bugfixes](https://github.com/golang/go/issues?q=milestone%3AGo1.19.6+label%3ACherryPickApproved) brought in by Go 1.19.6, including a few CVE fixes (though none appear to impact Mutagen).
