### PR TITLE
all: prepare for v0.17.0 release

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -10,10 +10,10 @@ of the Server Side Public License, the text of which can be found in
 sspl/LICENSE.
 
 From Mutagen v0.17 onward, SSPL-licensed code is included by default in official
-Mutagen builds, including the Mutagen sidecar image. Users wishing to create a
-Mutagen build with only MIT-licensed code can do so by running the build script
-and omitting the --sspl flag. The sidecar Dockerfile also includes a target that
-will build an image that includes only MIT-licensed Mutagen code.
+Mutagen release builds. Users wishing to create a Mutagen build with only
+MIT-licensed and non-copyleft-licensed code can do so by running the build
+script and omitting the --sspl flag. The sidecar Dockerfile also still defines
+both non-SSPL and SSPL targets, both of which are still currently shipped.
 
 --------------------------------------------------------------------------------
 

--- a/cmd/mutagen/sync/list_monitor_common.go
+++ b/cmd/mutagen/sync/list_monitor_common.go
@@ -14,7 +14,7 @@ import (
 	"github.com/mutagen-io/mutagen/pkg/synchronization"
 	"github.com/mutagen-io/mutagen/pkg/synchronization/core"
 	"github.com/mutagen-io/mutagen/pkg/synchronization/rsync"
-	"github.com/mutagen-io/mutagen/pkg/url"
+	urlpkg "github.com/mutagen-io/mutagen/pkg/url"
 )
 
 const (
@@ -82,7 +82,7 @@ func formatEntry(entry *core.Entry) string {
 }
 
 // printEndpoint prints the configuration for a synchronization endpoint.
-func printEndpoint(name string, url *url.URL, configuration *synchronization.Configuration, state *synchronization.EndpointState, version synchronization.Version, mode common.SessionDisplayMode) {
+func printEndpoint(name string, url *urlpkg.URL, configuration *synchronization.Configuration, state *synchronization.EndpointState, version synchronization.Version, mode common.SessionDisplayMode) {
 	// Print the endpoint header.
 	fmt.Printf("%s:\n", name)
 
@@ -166,12 +166,15 @@ func printEndpoint(name string, url *url.URL, configuration *synchronization.Con
 		}
 		fmt.Println("\t\tDefault file/directory group:", defaultGroupDescription)
 
-		// Compute and print the compression algorithm.
-		compressionAlgorithm := configuration.CompressionAlgorithm.Description()
-		if configuration.CompressionAlgorithm.IsDefault() {
-			compressionAlgorithm += fmt.Sprintf(" (%s)", version.DefaultCompressionAlgorithm().Description())
+		// If the endpoint is remote, then compute and print the compression
+		// algorithm.
+		if url.Protocol != urlpkg.Protocol_Local {
+			compressionAlgorithm := configuration.CompressionAlgorithm.Description()
+			if configuration.CompressionAlgorithm.IsDefault() {
+				compressionAlgorithm += fmt.Sprintf(" (%s)", version.DefaultCompressionAlgorithm().Description())
+			}
+			fmt.Println("\t\tCompression:", compressionAlgorithm)
 		}
-		fmt.Println("\t\tCompression:", compressionAlgorithm)
 	}
 
 	// At this point, there's no other status information that will be displayed

--- a/pkg/mutagen/version.go
+++ b/pkg/mutagen/version.go
@@ -19,7 +19,7 @@ const (
 	// VersionTag represents a tag to be appended to the Mutagen version string.
 	// It must not contain spaces. If empty, no tag is appended to the version
 	// string.
-	VersionTag = "nightly1"
+	VersionTag = ""
 )
 
 // DevelopmentModeEnabled indicates that development mode is active. This is


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This PR bumps the version to v0.17.0 and makes a clarification to the `LICENSE` file.

It also modifies synchronization session listings to hide compression algorithm information for local endpoints (where compression isn't used).
