### PR TITLE
deps: update Go versions to 1.20.3 and 1.19.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.20.1'
+          go-version: '1.20.3'
       - name: "Install sha256sum"
         run: brew install coreutils
       - run: scripts/ci/setup_go.sh
@@ -72,7 +72,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        goversion: ['1.19.6', '1.20.1']
+        goversion: ['1.19.8', '1.20.3']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.20.1'
+          go-version: '1.20.3'
       - run: scripts/ci/setup_go.sh
         shell: bash
       - run: scripts/ci/setup_docker.sh
@@ -116,7 +116,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.20.1'
+          go-version: '1.20.3'
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
       - uses: docker/login-action@v1

--- a/images/sidecar/linux/Dockerfile
+++ b/images/sidecar/linux/Dockerfile
@@ -1,5 +1,5 @@
 # Use an Alpine-based Go builder.
-FROM golang:1.20.1-alpine3.17 AS builder
+FROM golang:1.20.3-alpine3.17 AS builder
 
 # Disable cgo in order to match the behavior of our release binaries (and to
 # avoid the need for gcc on certain architectures).


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This PR updates the Go versions being used to 1.20.3 and 1.19.8.

**Which issue(s) does this pull request address (if any)?**

There are a number of compiler and runtime bugs fixed by these releases. There are also a few CVEs fixed in these releases, but none that affect Mutagen's use of Go.
