### PR TITLE
ci: ensure that go mod tidy doesn't cause changes

### DIFF
--- a/scripts/ci/analyze.sh
+++ b/scripts/ci/analyze.sh
@@ -10,6 +10,7 @@ FAILURE=0
 if [[ "$(go env GOOS)" != "windows" ]]; then
     gofmt -s -l -d . | tee gofmt.log
     if [[ -s gofmt.log ]]; then
+        echo "Code is not go fmt'd" 1>&2
         FAILURE=1
     fi
     rm gofmt.log

--- a/scripts/ci/analyze.sh
+++ b/scripts/ci/analyze.sh
@@ -15,6 +15,25 @@ if [[ "$(go env GOOS)" != "windows" ]]; then
     rm gofmt.log
 fi
 
+# Ensure that a go mod tidy operation doesn't change go.mod or go.sum. We skip
+# this check on Windows due to go mod tidy normalizing module files to LF
+# endings (and thus triggering a false positive).
+if [[ "$(go env GOOS)" != "windows" ]]; then
+    PRE_TIDY_GO_MOD_SUM=$(cat go.mod | openssl dgst -sha256)
+    PRE_TIDY_GO_SUM_SUM=$(cat go.sum | openssl dgst -sha256)
+    go mod tidy || FAILURE=1
+    POST_TIDY_GO_MOD_SUM=$(cat go.mod | openssl dgst -sha256)
+    POST_TIDY_GO_SUM_SUM=$(cat go.sum | openssl dgst -sha256)
+    if [[ "${POST_TIDY_GO_MOD_SUM}" != "${PRE_TIDY_GO_MOD_SUM}" ]]; then
+        echo "go.mod changed with go mod tidy operation" 1>&2
+        FAILURE=1
+    fi
+    if [[ "${POST_TIDY_GO_SUM_SUM}" != "${PRE_TIDY_GO_SUM_SUM}" ]]; then
+        echo "go.sum changed with go mod tidy operation" 1>&2
+        FAILURE=1
+    fi
+fi
+
 # Perform static analysis.
 go vet ./pkg/... || FAILURE=1
 go vet ./cmd/... || FAILURE=1

--- a/scripts/ci/notarize.sh
+++ b/scripts/ci/notarize.sh
@@ -26,6 +26,6 @@ if [[ "${MUTAGEN_OS_NAME}" == "darwin" ]]; then
     # Remove the archives.
     find "${RUNNER_TEMP}" -name 'notarize_*.zip' -exec rm -rf {} \;
 else
-    echo "This script is not supported on this platform"
+    echo "This script is not supported on this platform" 1>&2
     exit 1
 fi

--- a/scripts/ci/verify_commits.sh
+++ b/scripts/ci/verify_commits.sh
@@ -22,7 +22,7 @@ while read commit; do
     if [[ "${MAXIMUM_LINE_LENGTH}" -le "72" ]]; then
         echo "Commit message line length acceptable"
     else
-        echo "Commit message line length too long!"
+        echo "Commit message line length too long!" 1>&2
         exit 1
     fi
 
@@ -31,7 +31,7 @@ while read commit; do
     if git show --format="format:%B" --no-patch "${commit}" | grep -q "${EXPECTED_SIGNOFF}"; then
         echo "Found valid sign-off"
     else
-        echo "Missing sign-off!"
+        echo "Missing sign-off!" 1>&2
         exit 1
     fi
 
@@ -54,7 +54,7 @@ while read commit; do
     if [[ ! -z "$(git cat-file commit "${commit}" | sed "/^$/q" | grep "gpgsig ")" ]]; then
         echo "Found cryptographic signature"
     else
-        echo "Missing or invalid cryptographic signature!"
+        echo "Missing or invalid cryptographic signature!" 1>&2
         exit 1
     fi
 
@@ -67,7 +67,7 @@ done < <(git rev-list "${VERIFY_COMMIT_START}..${VERIFY_COMMIT_END}")
 
 # Enforce that at least one commit was verified.
 if [[ "${PERFORMED_VERIFICATION}" == "false" ]]; then
-    echo "No verification performed!"
+    echo "No verification performed!" 1>&2
     exit 1
 fi
 


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This PR adds an additional CI check to ensure that `go.mod` and `go.sum` are up-to-date (as defined by `go mod tidy`).  This is as important as a `go fmt` check.

This PR also normalizes writing of CI error messages to standard error.
