### PR TITLE
all: don't housekeep agents inside Mutagen sidecar containers

### DIFF
--- a/pkg/housekeeping/housekeep.go
+++ b/pkg/housekeeping/housekeep.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mutagen-io/mutagen/pkg/agent"
 	"github.com/mutagen-io/mutagen/pkg/filesystem"
 	"github.com/mutagen-io/mutagen/pkg/platform"
+	"github.com/mutagen-io/mutagen/pkg/sidecar"
 )
 
 const (
@@ -25,8 +26,14 @@ const (
 
 // Housekeep invokes housekeeping functions on the Mutagen data directory.
 func Housekeep() {
-	// Perform housekeeping on agent binaries.
-	housekeepAgents()
+	// Perform housekeeping on agent binaries, but only if we're not in a
+	// Mutagen sidecar container. Sidecar containers are particularly
+	// susceptible to stale agent access times due to the fact that the agent is
+	// baked into the sidecar image and the sidecar image is typically unpacked
+	// via OverlayFS on top of ext4 with either relatime or noatime.
+	if !sidecar.EnvironmentIsSidecar() {
+		housekeepAgents()
+	}
 
 	// Perform housekeeping on caches.
 	housekeepCaches()


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This PR causes agent housekeeping to be skipped in Mutagen sidecar containers.

Mutagen sidecar containers are typically unpacked via OverlayFS onto an ext4 filesystem with either relatime or noatime. In the case of an older sidecar image, this could result in the agent binary actually unlinking itself, which won't prevent it from functioning, but which will require reinstallation by the next session targeting the container (in which case the `fanotify` support of the built-in agent will typically be lost).
