### PR TITLE
cli: neutralize control characters in terminal output

### DIFF
--- a/cmd/mutagen/common/templating/templating.go
+++ b/cmd/mutagen/common/templating/templating.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"strings"
 	"text/template"
+
+	"github.com/mutagen-io/mutagen/pkg/platform/terminal"
 )
 
 // jsonify is the built-in JSON encoder that's made available to templates.
@@ -33,6 +35,7 @@ func jsonify(value any) (string, error) {
 
 // builtins are the builtin functions supported in output templates.
 var builtins = template.FuncMap{
-	"json": jsonify,
+	"json":          jsonify,
+	"shellSanitize": terminal.NeutralizeControlCharacters,
 	// TODO: Figure out what other functions we want to include here, if any.
 }

--- a/cmd/mutagen/forward/list_monitor_common.go
+++ b/cmd/mutagen/forward/list_monitor_common.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mutagen-io/mutagen/cmd/mutagen/common"
 
 	"github.com/mutagen-io/mutagen/pkg/forwarding"
+	"github.com/mutagen-io/mutagen/pkg/platform/terminal"
 	"github.com/mutagen-io/mutagen/pkg/selection"
 	"github.com/mutagen-io/mutagen/pkg/url"
 )
@@ -27,7 +28,7 @@ func printEndpoint(name string, url *url.URL, configuration *forwarding.Configur
 	fmt.Printf("%s:\n", name)
 
 	// Print the URL.
-	fmt.Println("\tURL:", url.Format("\n\t\t"))
+	fmt.Println("\tURL:", terminal.NeutralizeControlCharacters(url.Format("\n\t\t")))
 
 	// Print configuration information if desired.
 	if mode == common.SessionDisplayModeListLong || mode == common.SessionDisplayModeMonitorLong {
@@ -142,7 +143,7 @@ func printSession(state *forwarding.State, mode common.SessionDisplayMode) {
 
 	// Print the last error, if any.
 	if state.LastError != "" {
-		color.Red("Last error: %s\n", state.LastError)
+		color.Red("Last error: %s\n", terminal.NeutralizeControlCharacters(state.LastError))
 	}
 
 	// Print the session status .

--- a/cmd/mutagen/forward/monitor.go
+++ b/cmd/mutagen/forward/monitor.go
@@ -90,7 +90,7 @@ func monitorMain(_ *cobra.Command, arguments []string) error {
 	defer daemonConnection.Close()
 
 	// Create a session service client.
-	sessionService := forwardingsvc.NewForwardingClient(daemonConnection)
+	forwardingService := forwardingsvc.NewForwardingClient(daemonConnection)
 
 	// Create the list request that we'll use.
 	request := &forwardingsvc.ListRequest{
@@ -126,7 +126,7 @@ func monitorMain(_ *cobra.Command, arguments []string) error {
 		lastUpdateTime = now
 
 		// Perform a list operation.
-		response, err := sessionService.List(context.Background(), request)
+		response, err := forwardingService.List(context.Background(), request)
 		if err != nil {
 			return fmt.Errorf("list failed: %w", grpcutil.PeelAwayRPCErrorLayer(err))
 		} else if err = response.EnsureValid(); err != nil {

--- a/cmd/mutagen/sync/list_monitor_common.go
+++ b/cmd/mutagen/sync/list_monitor_common.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/mutagen-io/mutagen/cmd/mutagen/common"
 
+	"github.com/mutagen-io/mutagen/pkg/platform/terminal"
 	"github.com/mutagen-io/mutagen/pkg/selection"
 	"github.com/mutagen-io/mutagen/pkg/synchronization"
 	"github.com/mutagen-io/mutagen/pkg/synchronization/core"
@@ -87,7 +88,7 @@ func printEndpoint(name string, url *urlpkg.URL, configuration *synchronization.
 	fmt.Printf("%s:\n", name)
 
 	// Print the URL.
-	fmt.Println("\tURL:", url.Format("\n\t\t"))
+	fmt.Println("\tURL:", terminal.NeutralizeControlCharacters(url.Format("\n\t\t")))
 
 	// Print configuration information if desired.
 	if mode == common.SessionDisplayModeListLong || mode == common.SessionDisplayModeMonitorLong {
@@ -157,14 +158,14 @@ func printEndpoint(name string, url *urlpkg.URL, configuration *synchronization.
 		if configuration.DefaultOwner != "" {
 			defaultOwnerDescription = configuration.DefaultOwner
 		}
-		fmt.Println("\t\tDefault file/directory owner:", defaultOwnerDescription)
+		fmt.Println("\t\tDefault file/directory owner:", terminal.NeutralizeControlCharacters(defaultOwnerDescription))
 
 		// Compute and print the default file/directory group.
 		defaultGroupDescription := "Default"
 		if configuration.DefaultGroup != "" {
 			defaultGroupDescription = configuration.DefaultGroup
 		}
-		fmt.Println("\t\tDefault file/directory group:", defaultGroupDescription)
+		fmt.Println("\t\tDefault file/directory group:", terminal.NeutralizeControlCharacters(defaultGroupDescription))
 
 		// If the endpoint is remote, then compute and print the compression
 		// algorithm.
@@ -205,7 +206,10 @@ func printEndpoint(name string, url *urlpkg.URL, configuration *synchronization.
 		} else if mode == common.SessionDisplayModeListLong {
 			color.Red("\tScan problems:\n")
 			for _, p := range state.ScanProblems {
-				color.Red("\t\t%s: %v\n", formatPath(p.Path), p.Error)
+				color.Red("\t\t%s: %v\n",
+					terminal.NeutralizeControlCharacters(formatPath(p.Path)),
+					terminal.NeutralizeControlCharacters(p.Error),
+				)
 			}
 			if state.ExcludedScanProblems > 0 {
 				color.Red("\t\t...+%d more...\n", state.ExcludedScanProblems)
@@ -222,7 +226,10 @@ func printEndpoint(name string, url *urlpkg.URL, configuration *synchronization.
 		} else if mode == common.SessionDisplayModeListLong {
 			color.Red("\tTransition problems:\n")
 			for _, p := range state.TransitionProblems {
-				color.Red("\t\t%s: %v\n", formatPath(p.Path), p.Error)
+				color.Red("\t\t%s: %v\n",
+					terminal.NeutralizeControlCharacters(formatPath(p.Path)),
+					terminal.NeutralizeControlCharacters(p.Error),
+				)
 			}
 			if state.ExcludedTransitionProblems > 0 {
 				color.Red("\t\t...+%d more...\n", state.ExcludedTransitionProblems)
@@ -247,9 +254,9 @@ func printConflicts(conflicts []*core.Conflict, excludedConflicts uint64) {
 		for _, a := range c.AlphaChanges {
 			color.Red(
 				"\t(alpha) %s (%s -> %s)\n",
-				formatPath(a.Path),
-				formatEntry(a.Old),
-				formatEntry(a.New),
+				terminal.NeutralizeControlCharacters(formatPath(a.Path)),
+				terminal.NeutralizeControlCharacters(formatEntry(a.Old)),
+				terminal.NeutralizeControlCharacters(formatEntry(a.New)),
 			)
 		}
 
@@ -257,9 +264,9 @@ func printConflicts(conflicts []*core.Conflict, excludedConflicts uint64) {
 		for _, b := range c.BetaChanges {
 			color.Red(
 				"\t(beta)  %s (%s -> %s)\n",
-				formatPath(b.Path),
-				formatEntry(b.Old),
-				formatEntry(b.New),
+				terminal.NeutralizeControlCharacters(formatPath(b.Path)),
+				terminal.NeutralizeControlCharacters(formatEntry(b.Old)),
+				terminal.NeutralizeControlCharacters(formatEntry(b.New)),
 			)
 		}
 
@@ -374,7 +381,7 @@ func printSession(state *synchronization.State, mode common.SessionDisplayMode) 
 		if len(configuration.DefaultIgnores) > 0 {
 			fmt.Println("\tDefault ignores:")
 			for _, p := range configuration.DefaultIgnores {
-				fmt.Printf("\t\t%s\n", p)
+				fmt.Printf("\t\t%s\n", terminal.NeutralizeControlCharacters(p))
 			}
 		}
 
@@ -382,7 +389,7 @@ func printSession(state *synchronization.State, mode common.SessionDisplayMode) 
 		if len(configuration.Ignores) > 0 {
 			fmt.Println("\tIgnores:")
 			for _, p := range configuration.Ignores {
-				fmt.Printf("\t\t%s\n", p)
+				fmt.Printf("\t\t%s\n", terminal.NeutralizeControlCharacters(p))
 			}
 		} else {
 			fmt.Println("\tIgnores: None")
@@ -439,7 +446,7 @@ func printSession(state *synchronization.State, mode common.SessionDisplayMode) 
 
 	// Print the last error, if any.
 	if state.LastError != "" {
-		color.Red("Last error: %s\n", state.LastError)
+		color.Red("Last error: %s\n", terminal.NeutralizeControlCharacters(state.LastError))
 	}
 
 	// Print the session status .
@@ -477,7 +484,7 @@ func printSession(state *synchronization.State, mode common.SessionDisplayMode) 
 			stagingProgress.ReceivedFiles, stagingProgress.ExpectedFiles,
 			humanize.Bytes(stagingProgress.TotalReceivedSize), totalSizeDenominator,
 			100.0*fractionComplete,
-			stagingProgress.Path,
+			terminal.NeutralizeControlCharacters(stagingProgress.Path),
 			humanize.Bytes(stagingProgress.ReceivedSize), humanize.Bytes(stagingProgress.ExpectedSize),
 		)
 	}

--- a/cmd/mutagen/sync/monitor.go
+++ b/cmd/mutagen/sync/monitor.go
@@ -21,6 +21,7 @@ import (
 
 	synchronizationmodels "github.com/mutagen-io/mutagen/pkg/api/models/synchronization"
 	"github.com/mutagen-io/mutagen/pkg/grpcutil"
+	"github.com/mutagen-io/mutagen/pkg/platform/terminal"
 	selectionpkg "github.com/mutagen-io/mutagen/pkg/selection"
 	synchronizationsvc "github.com/mutagen-io/mutagen/pkg/service/synchronization"
 	"github.com/mutagen-io/mutagen/pkg/synchronization"
@@ -97,7 +98,7 @@ func computeMonitorStatusLine(state *synchronization.State) string {
 				stagingProgress.ReceivedFiles, stagingProgress.ExpectedFiles,
 				humanize.Bytes(stagingProgress.TotalReceivedSize), totalSizeDenominator,
 				100.0*fractionComplete,
-				path.Base(stagingProgress.Path),
+				terminal.NeutralizeControlCharacters(path.Base(stagingProgress.Path)),
 				humanize.Bytes(stagingProgress.ReceivedSize), humanize.Bytes(stagingProgress.ExpectedSize),
 			)
 		}
@@ -140,7 +141,7 @@ func monitorMain(_ *cobra.Command, arguments []string) error {
 	defer daemonConnection.Close()
 
 	// Create a session service client.
-	sessionService := synchronizationsvc.NewSynchronizationClient(daemonConnection)
+	synchronizationService := synchronizationsvc.NewSynchronizationClient(daemonConnection)
 
 	// Create the list request that we'll use.
 	request := &synchronizationsvc.ListRequest{
@@ -176,7 +177,7 @@ func monitorMain(_ *cobra.Command, arguments []string) error {
 		lastUpdateTime = now
 
 		// Perform a list operation.
-		response, err := sessionService.List(context.Background(), request)
+		response, err := synchronizationService.List(context.Background(), request)
 		if err != nil {
 			return fmt.Errorf("list failed: %w", grpcutil.PeelAwayRPCErrorLayer(err))
 		} else if err = response.EnsureValid(); err != nil {

--- a/pkg/agent/dial.go
+++ b/pkg/agent/dial.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mutagen-io/mutagen/pkg/filesystem"
 	"github.com/mutagen-io/mutagen/pkg/logging"
 	"github.com/mutagen-io/mutagen/pkg/mutagen"
+	"github.com/mutagen-io/mutagen/pkg/platform/terminal"
 	"github.com/mutagen-io/mutagen/pkg/prompting"
 	streampkg "github.com/mutagen-io/mutagen/pkg/stream"
 )
@@ -129,13 +130,14 @@ func connect(logger *logging.Logger, transport Transport, mode, prompter string,
 		// which is all we care about.
 		stream.Close()
 
-		// Extract any error output, ensure that it's UTF-8, and strip out any
-		// whitespace (primarily trailing newlines).
+		// Extract any error output, ensure that it's UTF-8, strip out any
+		// whitespace (primarily trailing newlines), and neutralize any control
+		// characters.
 		errorOutput := errorBuffer.String()
 		if !utf8.ValidString(errorOutput) {
 			return nil, false, false, errors.New("remote did not return UTF-8 output")
 		}
-		errorOutput = strings.TrimSpace(errorOutput)
+		errorOutput = terminal.NeutralizeControlCharacters(strings.TrimSpace(errorOutput))
 
 		// Wrap up the handshake error with additional context.
 		if errorOutput != "" {

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mutagen-io/mutagen/pkg/platform/terminal"
 	"github.com/mutagen-io/mutagen/pkg/stream"
 )
 
@@ -24,7 +25,8 @@ type Logger struct {
 
 // NewLogger creates a new logger at the specified log level targeting the
 // specified writer. The writer must be non-nil. The logger and any derived
-// subloggers will coordinate access to the writer.
+// subloggers will coordinate access to the writer. Any terminal control
+// characters will be neutralized before being written to the log.
 func NewLogger(level Level, writer io.Writer) *Logger {
 	return &Logger{
 		level:  level,
@@ -108,6 +110,9 @@ func (l *Logger) write(timestamp time.Time, level Level, message string) {
 			timestamp.Format(timestampFormat), level.abbreviation(), message,
 		)
 	}
+
+	// Neutralize any control characters in the line.
+	line = terminal.NeutralizeControlCharacters(line)
 
 	// Write the line. We can't do much with the error here, so we don't try.
 	// Practically speaking, most io.Writer implementations perform retries if a
@@ -247,6 +252,9 @@ func (l *Logger) Writer(level Level) io.Writer {
 			} else {
 				line = line + "\n"
 			}
+
+			// Neutralize any control characters in the line.
+			line = terminal.NeutralizeControlCharacters(line)
 
 			// Write the line to the underlying writer.
 			l.writer.Write([]byte(line))

--- a/pkg/platform/terminal/doc.go
+++ b/pkg/platform/terminal/doc.go
@@ -1,0 +1,2 @@
+// Package terminal provides utilities for working with terminals.
+package terminal

--- a/pkg/platform/terminal/neutralization.go
+++ b/pkg/platform/terminal/neutralization.go
@@ -1,0 +1,18 @@
+package terminal
+
+import (
+	"strings"
+)
+
+// controlCharacterNeutralizer is a string replacer that terminal neutralizes
+// control characters.
+var controlCharacterNeutralizer = strings.NewReplacer(
+	"\x1b", "^[",
+	"\r", "\\r",
+)
+
+// NeutralizeControlCharacters returns a copy of a string with any terminal
+// control characters neutralized.
+func NeutralizeControlCharacters(value string) string {
+	return controlCharacterNeutralizer.Replace(value)
+}

--- a/pkg/process/errors.go
+++ b/pkg/process/errors.go
@@ -4,6 +4,8 @@ import (
 	"os/exec"
 	"strings"
 	"unicode/utf8"
+
+	"github.com/mutagen-io/mutagen/pkg/platform/terminal"
 )
 
 const (
@@ -42,10 +44,11 @@ func OutputIsWindowsCommandNotFound(output string) bool {
 // the Stderr portion of the specified error, assuming it is an
 // os/exec.ExitError. If the error is not an os/exec.ExitError, or if the Stderr
 // field is not UTF-8 encoded, or if the message in Stderr is empty after
-// stripping surrounding white space, then an empty string is returned.
+// stripping surrounding white space, then an empty string is returned. This
+// function will perform control character neutralization on any returned value.
 func ExtractExitErrorMessage(err error) string {
 	if exitErr, ok := err.(*exec.ExitError); ok && utf8.Valid(exitErr.Stderr) {
-		return strings.TrimSpace(string(exitErr.Stderr))
+		return terminal.NeutralizeControlCharacters(strings.TrimSpace(string(exitErr.Stderr)))
 	}
 	return ""
 }


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This PR adds neutralization (escaping) of control characters in terminal output for values that aren't locally controlled. This output (if unsanitized) could cause terminal corruption. In theory, it could also be used as an attack vector for intentionally causing terminal corruption when synchronizing with an untrusted (and malicious) remote. On very old terminal emulators, it can theoretically be used as an attack vector for code execution (see, for example, CVE-2003-0069), though this type of vulnerability has been patched for over 20 years.

We still treat the daemon as a trusted entity (since it is under user control) and don't sanitize (most) output under its control (such as locally generated error messages).

We intentionally avoid sanitizing templated output because that output needs to contain raw, unmodified values. A shellSanitize function has been added to support neutralization of control characters in template output.

**Which issue(s) does this pull request address (if any)?**

GHSA-jmp2-wc4p-wfh2 / CVE-2023-30844
