### PR TITLE
all: prepare for v0.17.2 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.20.4'
+          go-version: '1.20.5'
       - name: "Install sha256sum"
         run: brew install coreutils
       - run: scripts/ci/setup_go.sh
@@ -72,7 +72,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        goversion: ['1.19.9', '1.20.4']
+        goversion: ['1.19.10', '1.20.5']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.20.4'
+          go-version: '1.20.5'
       - run: scripts/ci/setup_go.sh
         shell: bash
       - run: scripts/ci/setup_docker.sh
@@ -116,7 +116,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.20.4'
+          go-version: '1.20.5'
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
       - uses: docker/login-action@v1

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/klauspost/compress v1.15.14
 	github.com/mattn/go-isatty v0.0.16
 	github.com/mutagen-io/extstat v0.0.0-20210224131814-32fa3f057fa8
-	github.com/mutagen-io/fsevents v0.0.0-20180903111129-10556809b434
+	github.com/mutagen-io/fsevents v0.0.0-20230629001834-f53e17b91ebc
 	github.com/mutagen-io/gopass v0.0.0-20230214181532-d4b7cdfe054c
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,8 @@ github.com/mutagen-io/apimachinery v0.21.3-mutagen1 h1:7bnH35Ayna8ERRINDJ+J+bRd/
 github.com/mutagen-io/apimachinery v0.21.3-mutagen1/go.mod h1:H/IM+5vH9kZRNJ4l3x/fXP/5bOPJaVP/guptnZPeCFI=
 github.com/mutagen-io/extstat v0.0.0-20210224131814-32fa3f057fa8 h1:NEBqH/oVnWBunxdrdy1vlyGior8smhC6jZjxlWSG2BU=
 github.com/mutagen-io/extstat v0.0.0-20210224131814-32fa3f057fa8/go.mod h1:ZHGnLARFvfv0lUb6FsAS+LJHt9CFemt7K+mWfkw8nVA=
-github.com/mutagen-io/fsevents v0.0.0-20180903111129-10556809b434 h1:PYeqqury0vVzjjUVO6dwtfA2HXOaPYgDclSgKX8u0gs=
-github.com/mutagen-io/fsevents v0.0.0-20180903111129-10556809b434/go.mod h1:kmTyqetTEgYl9KF5JlHLKL6LXnhs2/oK5100pcMZRn8=
+github.com/mutagen-io/fsevents v0.0.0-20230629001834-f53e17b91ebc h1:yOGQ0Hc3NfOWYm9aaluKJEOZWEbpCPEm/TbPU87YumM=
+github.com/mutagen-io/fsevents v0.0.0-20230629001834-f53e17b91ebc/go.mod h1:kmTyqetTEgYl9KF5JlHLKL6LXnhs2/oK5100pcMZRn8=
 github.com/mutagen-io/gopass v0.0.0-20230214181532-d4b7cdfe054c h1:c0xgZ8mF6PwiDc6aW2MEcdaCXxkt5K30kzylWqkT4oc=
 github.com/mutagen-io/gopass v0.0.0-20230214181532-d4b7cdfe054c/go.mod h1:Q87jWQAqEC/UdnYLd+A0mfR9oZl5gk6g/xvxzTpwLv8=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=

--- a/images/sidecar/linux/Dockerfile
+++ b/images/sidecar/linux/Dockerfile
@@ -1,5 +1,5 @@
 # Use an Alpine-based Go builder.
-FROM golang:1.20.4-alpine3.17 AS builder
+FROM golang:1.20.5-alpine3.17 AS builder
 
 # Disable cgo in order to match the behavior of our release binaries (and to
 # avoid the need for gcc on certain architectures).

--- a/pkg/mutagen/version.go
+++ b/pkg/mutagen/version.go
@@ -15,7 +15,7 @@ const (
 	// VersionMinor represents the current minor version of Mutagen.
 	VersionMinor = 17
 	// VersionPatch represents the current patch version of Mutagen.
-	VersionPatch = 1
+	VersionPatch = 2
 	// VersionTag represents a tag to be appended to the Mutagen version string.
 	// It must not contain spaces. If empty, no tag is appended to the version
 	// string.


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This PR backports updates to the v0.17.x release branch in preparation for the v0.17.2 release.  In particular, it:

- Updates Go to 1.20.5 and 1.19.10 
    - These contain a fix for CVE-2023-29403, which could affect users in the (unlikely) event that they're using Mutagen with `setuid`/`setgid`
- Updates github.com/mutagen-io/fsevents
    - This contains a fix for a symbol collision issue with the upstream github.com/fsnotify/fsevents
- Bumps the release version to v0.17.2

**Which issue(s) does this pull request address (if any)?**

This should help unblock mutagen-io/mutagen-compose#64.
