### PR TITLE
Turn `AcquireLock` more reusable by adding path as parameter

### DIFF
--- a/cmd/mutagen/daemon/run.go
+++ b/cmd/mutagen/daemon/run.go
@@ -35,7 +35,7 @@ import (
 // runMain is the entry point for the run command.
 func runMain(_ *cobra.Command, _ []string) error {
 	// Attempt to acquire the daemon lock and defer its release.
-	lock, err := daemon.AcquireLock()
+	lock, err := daemon.AcquireLock("")
 	if err != nil {
 		return fmt.Errorf("unable to acquire daemon lock: %w", err)
 	}

--- a/pkg/daemon/lock.go
+++ b/pkg/daemon/lock.go
@@ -14,11 +14,15 @@ type Lock struct {
 }
 
 // AcquireLock attempts to acquire the global daemon lock.
-func AcquireLock() (*Lock, error) {
-	// Compute the lock path.
-	lockPath, err := subpath(lockName)
-	if err != nil {
-		return nil, fmt.Errorf("unable to compute daemon lock path: %w", err)
+func AcquireLock(path string) (*Lock, error) {
+	var err error
+	lockPath := path
+	if lockPath == "" {
+		// Compute the lock path.
+		lockPath, err = subpath(lockName)
+		if err != nil {
+			return nil, fmt.Errorf("unable to compute daemon lock path: %w", err)
+		}
 	}
 
 	// Create the locker and attempt to acquire the lock.

--- a/pkg/daemon/lock_test.go
+++ b/pkg/daemon/lock_test.go
@@ -7,7 +7,7 @@ import (
 // TestLockCycle tests an acquisition/release cycle of the daemon lock.
 func TestLockCycle(t *testing.T) {
 	// Attempt to acquire the daemon lock.
-	lock, err := AcquireLock()
+	lock, err := AcquireLock("")
 	if err != nil {
 		t.Fatal("unable to acquire lock:", err)
 	}

--- a/pkg/daemon/register_darwin.go
+++ b/pkg/daemon/register_darwin.go
@@ -76,7 +76,7 @@ func Register() error {
 	// start and stop mechanism depending on whether or not we're registered, so
 	// we need to make sure we don't try to stop a daemon started using a
 	// different mechanism.
-	lock, err := AcquireLock()
+	lock, err := AcquireLock("")
 	if err != nil {
 		return errors.New("unable to alter registration while daemon is running")
 	}
@@ -132,7 +132,7 @@ func Unregister() error {
 	// start and stop mechanism depending on whether or not we're registered, so
 	// we need to make sure we don't try to stop a daemon started using a
 	// different mechanism.
-	lock, err := AcquireLock()
+	lock, err := AcquireLock("")
 	if err != nil {
 		return errors.New("unable to alter registration while daemon is running")
 	}

--- a/pkg/integration/integration_test.go
+++ b/pkg/integration/integration_test.go
@@ -49,7 +49,7 @@ func TestMain(m *testing.M) {
 	agent.ExpectedBundleLocation = agent.BundleLocationBuildDirectory
 
 	// Acquire the daemon lock and defer its release.
-	lock, err := daemon.AcquireLock()
+	lock, err := daemon.AcquireLock("")
 	if err != nil {
 		cmd.Fatal(fmt.Errorf("unable to acquire daemon lock: %w", err))
 	}


### PR DESCRIPTION
<!--

Thanks for the pull request! Before submitting, please ensure that your commits
adhere to the guidelines in CONTRIBUTING.md. Pull requests that do not meet
these guidelines cannot be merged.

If you're not quite ready for a final review, please feel free to open a draft
pull request.

Thanks for taking the time to open a pull request!

-->

**What does this pull request do and why is it needed?**
This PR intents to turn `AcquireLock` more reusable by adding path as parameter. It conserves the previous behaviour in the case of an empty `path`.

Another alternative would be implementing this with varargs to void changing all the calls
