### PR TITLE
all: prepare for v0.17.4 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.20.11'
+          go-version: '1.20.12'
       - name: "Install sha256sum"
         run: brew install coreutils
       - run: scripts/ci/setup_go.sh
@@ -72,7 +72,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        goversion: ['1.19.13', '1.20.11']
+        goversion: ['1.19.13', '1.20.12']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.20.11'
+          go-version: '1.20.12'
       - run: scripts/ci/setup_go.sh
         shell: bash
       - run: scripts/ci/setup_docker.sh
@@ -116,7 +116,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.20.11'
+          go-version: '1.20.12'
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
       - uses: docker/login-action@v1

--- a/images/sidecar/linux/Dockerfile
+++ b/images/sidecar/linux/Dockerfile
@@ -1,5 +1,5 @@
 # Use an Alpine-based Go builder.
-FROM golang:1.20.11-alpine3.18 AS builder
+FROM golang:1.20.12-alpine3.18 AS builder
 
 # Disable cgo in order to match the behavior of our release binaries (and to
 # avoid the need for gcc on certain architectures).

--- a/pkg/mutagen/version.go
+++ b/pkg/mutagen/version.go
@@ -15,7 +15,7 @@ const (
 	// VersionMinor represents the current minor version of Mutagen.
 	VersionMinor = 17
 	// VersionPatch represents the current patch version of Mutagen.
-	VersionPatch = 3
+	VersionPatch = 4
 	// VersionTag represents a tag to be appended to the Mutagen version string.
 	// It must not contain spaces. If empty, no tag is appended to the version
 	// string.


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This PR updates the Go dependency to 1.20.12 and bumps the version to v0.17.4.
