### PR TITLE
Log unhandled errors if they occur

### DIFF
--- a/cmd/mutagen-agent/synchronizer.go
+++ b/cmd/mutagen-agent/synchronizer.go
@@ -29,7 +29,7 @@ func housekeepRegularly(ctx context.Context, logger *logging.Logger) {
 	// Perform an initial housekeeping operation since the ticker won't fire
 	// straight away.
 	logger.Info("Performing initial housekeeping")
-	housekeeping.Housekeep()
+	housekeeping.Housekeep(logger)
 
 	// Create a ticker to regulate housekeeping and defer its shutdown.
 	ticker := time.NewTicker(housekeepingInterval)
@@ -42,7 +42,7 @@ func housekeepRegularly(ctx context.Context, logger *logging.Logger) {
 			return
 		case <-ticker.C:
 			logger.Info("Performing regular housekeeping")
-			housekeeping.Housekeep()
+			housekeeping.Housekeep(logger)
 		}
 	}
 }

--- a/cmd/mutagen/daemon/register.go
+++ b/cmd/mutagen/daemon/register.go
@@ -1,6 +1,9 @@
 package daemon
 
 import (
+	"os"
+
+	"github.com/mutagen-io/mutagen/pkg/logging"
 	"github.com/spf13/cobra"
 
 	"github.com/mutagen-io/mutagen/cmd"
@@ -10,7 +13,8 @@ import (
 
 // registerMain is the entry point for the register command.
 func registerMain(_ *cobra.Command, _ []string) error {
-	return daemon.Register()
+	logger := logging.NewLogger(logging.LevelError, os.Stderr)
+	return daemon.Register(logger)
 }
 
 // registerCommand is the register command.

--- a/cmd/mutagen/daemon/unregister.go
+++ b/cmd/mutagen/daemon/unregister.go
@@ -1,16 +1,19 @@
 package daemon
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 
 	"github.com/mutagen-io/mutagen/cmd"
-
 	"github.com/mutagen-io/mutagen/pkg/daemon"
+	"github.com/mutagen-io/mutagen/pkg/logging"
 )
 
 // unregisterMain is the entry point for the unregister command.
 func unregisterMain(_ *cobra.Command, _ []string) error {
-	return daemon.Unregister()
+	logger := logging.NewLogger(logging.LevelError, os.Stderr)
+	return daemon.Unregister(logger)
 }
 
 // unregisterCommand is the unregister command.

--- a/cmd/mutagen/project/pause.go
+++ b/cmd/mutagen/project/pause.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/mutagen-io/mutagen/pkg/logging"
+	"github.com/mutagen-io/mutagen/pkg/must"
 	"github.com/spf13/cobra"
 
 	"github.com/mutagen-io/mutagen/cmd"
@@ -23,6 +25,8 @@ import (
 
 // pauseMain is the entry point for the pause command.
 func pauseMain(_ *cobra.Command, _ []string) error {
+	logger := logging.NewLogger(logging.LevelError, os.Stderr)
+
 	// Compute the name of the configuration file and ensure that our working
 	// directory is that in which the file resides. This is required for
 	// relative paths (including relative synchronization paths and relative
@@ -52,9 +56,9 @@ func pauseMain(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("unable to create project locker: %w", err)
 	}
 	defer func() {
-		locker.Close()
+		must.Close(locker, logger)
 		if removeLockFileOnReturn && runtime.GOOS == "windows" {
-			os.Remove(lockPath)
+			must.OSRemove(lockPath, logger)
 		}
 	}()
 
@@ -71,12 +75,12 @@ func pauseMain(_ *cobra.Command, _ []string) error {
 	defer func() {
 		if removeLockFileOnReturn {
 			if runtime.GOOS == "windows" {
-				locker.Truncate(0)
+				must.Truncate(locker, 0, logger)
 			} else {
-				os.Remove(lockPath)
+				must.OSRemove(lockPath, logger)
 			}
 		}
-		locker.Unlock()
+		must.Unlock(locker, logger)
 	}()
 
 	// Read the project identifier from the lock file. If the lock file is
@@ -115,7 +119,7 @@ func pauseMain(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("unable to connect to daemon: %w", err)
 	}
-	defer daemonConnection.Close()
+	defer must.Close(daemonConnection, logger)
 
 	// Compute the selection that we're going to use to pause sessions.
 	selection := &selection.Selection{

--- a/cmd/mutagen/project/reset.go
+++ b/cmd/mutagen/project/reset.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/mutagen-io/mutagen/pkg/logging"
+	"github.com/mutagen-io/mutagen/pkg/must"
 	"github.com/spf13/cobra"
 
 	"github.com/mutagen-io/mutagen/cmd"
@@ -22,6 +24,7 @@ import (
 
 // resetMain is the entry point for the reset command.
 func resetMain(_ *cobra.Command, _ []string) error {
+	logger := logging.NewLogger(logging.LevelError, os.Stderr)
 	// Compute the name of the configuration file and ensure that our working
 	// directory is that in which the file resides. This is required for
 	// relative paths (including relative synchronization paths and relative
@@ -51,9 +54,9 @@ func resetMain(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("unable to create project locker: %w", err)
 	}
 	defer func() {
-		locker.Close()
+		must.Close(locker, logger)
 		if removeLockFileOnReturn && runtime.GOOS == "windows" {
-			os.Remove(lockPath)
+			must.OSRemove(lockPath, logger)
 		}
 	}()
 
@@ -70,12 +73,12 @@ func resetMain(_ *cobra.Command, _ []string) error {
 	defer func() {
 		if removeLockFileOnReturn {
 			if runtime.GOOS == "windows" {
-				locker.Truncate(0)
+				must.Truncate(locker, 0, logger)
 			} else {
-				os.Remove(lockPath)
+				must.OSRemove(lockPath, logger)
 			}
 		}
-		locker.Unlock()
+		must.Unlock(locker, logger)
 	}()
 
 	// Read the project identifier from the lock file. If the lock file is
@@ -100,7 +103,7 @@ func resetMain(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("unable to connect to daemon: %w", err)
 	}
-	defer daemonConnection.Close()
+	defer must.Close(daemonConnection, logger)
 
 	// Compute the selection that we're going to use to reset sessions.
 	selection := &selection.Selection{

--- a/cmd/mutagen/project/resume.go
+++ b/cmd/mutagen/project/resume.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/mutagen-io/mutagen/pkg/logging"
+	"github.com/mutagen-io/mutagen/pkg/must"
 	"github.com/spf13/cobra"
 
 	"github.com/mutagen-io/mutagen/cmd"
@@ -23,6 +25,8 @@ import (
 
 // resumeMain is the entry point for the resume command.
 func resumeMain(_ *cobra.Command, _ []string) error {
+	logger := logging.NewLogger(logging.LevelError, os.Stderr)
+
 	// Compute the name of the configuration file and ensure that our working
 	// directory is that in which the file resides. This is required for
 	// relative paths (including relative synchronization paths and relative
@@ -52,9 +56,9 @@ func resumeMain(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("unable to create project locker: %w", err)
 	}
 	defer func() {
-		locker.Close()
+		must.Close(locker, logger)
 		if removeLockFileOnReturn && runtime.GOOS == "windows" {
-			os.Remove(lockPath)
+			must.OSRemove(lockPath, logger)
 		}
 	}()
 
@@ -71,12 +75,12 @@ func resumeMain(_ *cobra.Command, _ []string) error {
 	defer func() {
 		if removeLockFileOnReturn {
 			if runtime.GOOS == "windows" {
-				locker.Truncate(0)
+				must.Truncate(locker, 0, logger)
 			} else {
-				os.Remove(lockPath)
+				must.OSRemove(lockPath, logger)
 			}
 		}
-		locker.Unlock()
+		must.Unlock(locker, logger)
 	}()
 
 	// Read the project identifier from the lock file. If the lock file is

--- a/cmd/mutagen/project/terminate.go
+++ b/cmd/mutagen/project/terminate.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/mutagen-io/mutagen/pkg/logging"
+	"github.com/mutagen-io/mutagen/pkg/must"
 	"github.com/spf13/cobra"
 
 	"github.com/mutagen-io/mutagen/cmd"
@@ -23,6 +25,8 @@ import (
 
 // terminateMain is the entry point for the terminate command.
 func terminateMain(_ *cobra.Command, _ []string) error {
+	logger := logging.NewLogger(logging.LevelError, &bytes.Buffer{})
+
 	// Compute the name of the configuration file and ensure that our working
 	// directory is that in which the file resides. This is required for
 	// relative paths (including relative synchronization paths and relative
@@ -52,9 +56,9 @@ func terminateMain(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("unable to create project locker: %w", err)
 	}
 	defer func() {
-		locker.Close()
+		must.Close(locker, logger)
 		if removeLockFileOnReturn && runtime.GOOS == "windows" {
-			os.Remove(lockPath)
+			must.OSRemove(lockPath, logger)
 		}
 	}()
 
@@ -71,12 +75,12 @@ func terminateMain(_ *cobra.Command, _ []string) error {
 	defer func() {
 		if removeLockFileOnReturn {
 			if runtime.GOOS == "windows" {
-				locker.Truncate(0)
+				must.Truncate(locker, 0, logger)
 			} else {
-				os.Remove(lockPath)
+				must.OSRemove(lockPath, logger)
 			}
 		}
-		locker.Unlock()
+		must.Unlock(locker, logger)
 	}()
 
 	// Read the project identifier from the lock file. If the lock file is
@@ -115,7 +119,7 @@ func terminateMain(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("unable to connect to daemon: %w", err)
 	}
-	defer daemonConnection.Close()
+	defer must.Close(daemonConnection, logger)
 
 	// Compute the selection that we're going to use to terminate sessions.
 	selection := &selection.Selection{

--- a/cmd/mutagen/sync/create.go
+++ b/cmd/mutagen/sync/create.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/mutagen-io/mutagen/pkg/logging"
+	"github.com/mutagen-io/mutagen/pkg/must"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -96,6 +98,11 @@ func CreateWithSpecification(
 
 // createMain is the entry point for the create command.
 func createMain(_ *cobra.Command, arguments []string) error {
+
+	// Set up a logger on the standard error stream.
+	// TODO: Make this configurable
+	logger := logging.NewLogger(logging.LevelError, os.Stderr)
+
 	// Validate, extract, and parse URLs.
 	if len(arguments) != 2 {
 		return errors.New("invalid number of endpoint URLs provided")
@@ -501,7 +508,7 @@ func createMain(_ *cobra.Command, arguments []string) error {
 	if err != nil {
 		return fmt.Errorf("unable to connect to daemon: %w", err)
 	}
-	defer daemonConnection.Close()
+	defer must.Close(daemonConnection, logger)
 
 	// Perform the create operation.
 	identifier, err := CreateWithSpecification(daemonConnection, specification)

--- a/cmd/mutagen/sync/main.go
+++ b/cmd/mutagen/sync/main.go
@@ -1,16 +1,22 @@
 package sync
 
 import (
+	"os"
+
+	"github.com/mutagen-io/mutagen/pkg/logging"
+	"github.com/mutagen-io/mutagen/pkg/must"
 	"github.com/spf13/cobra"
 )
 
 // syncMain is the entry point for the sync command.
 func syncMain(command *cobra.Command, arguments []string) error {
+	logger := logging.NewLogger(logging.LevelError, os.Stderr)
+
 	// If no commands were given, then print help information and bail. We don't
 	// have to worry about warning about arguments being present here (which
 	// would be incorrect usage) because arguments can't even reach this point
 	// (they will be mistaken for subcommands and a error will be displayed).
-	command.Help()
+	must.CommandHelp(command, logger)
 
 	// Success.
 	return nil

--- a/pkg/agent/bundle_test.go
+++ b/pkg/agent/bundle_test.go
@@ -1,16 +1,20 @@
 package agent
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	"github.com/mutagen-io/mutagen/pkg/logging"
 )
 
 // TestExecutableForInvalidOS tests that ExecutableForPlatform fails for an
 // invalid OS specification.
 func TestExecutableForInvalidOS(t *testing.T) {
-	if _, err := ExecutableForPlatform("fakeos", runtime.GOARCH, ""); err == nil {
+	logger := logging.NewLogger(logging.LevelError, &bytes.Buffer{})
+	if _, err := ExecutableForPlatform("fakeos", runtime.GOARCH, "", logger); err == nil {
 		t.Fatal("extracting agent executable succeeded for invalid OS")
 	}
 }
@@ -18,7 +22,8 @@ func TestExecutableForInvalidOS(t *testing.T) {
 // TestExecutableForInvalidArchitecture tests that ExecutableForPlatform fails
 // for an invalid architecture specification.
 func TestExecutableForInvalidArchitecture(t *testing.T) {
-	if _, err := ExecutableForPlatform(runtime.GOOS, "fakearch", ""); err == nil {
+	logger := logging.NewLogger(logging.LevelError, &bytes.Buffer{})
+	if _, err := ExecutableForPlatform(runtime.GOOS, "fakearch", "", logger); err == nil {
 		t.Fatal("extracting agent executable succeeded for invalid architecture")
 	}
 }
@@ -26,7 +31,8 @@ func TestExecutableForInvalidArchitecture(t *testing.T) {
 // TestExecutableForInvalidPair tests that ExecutableForPlatform fails for an
 // invalid OS/architecture specification.
 func TestExecutableForInvalidPair(t *testing.T) {
-	if _, err := ExecutableForPlatform("fakeos", "fakearch", ""); err == nil {
+	logger := logging.NewLogger(logging.LevelError, &bytes.Buffer{})
+	if _, err := ExecutableForPlatform("fakeos", "fakearch", "", logger); err == nil {
 		t.Fatal("extracting agent executable succeeded for invalid architecture")
 	}
 }
@@ -34,7 +40,8 @@ func TestExecutableForInvalidPair(t *testing.T) {
 // TestExecutableForPlatform tests that ExecutableForPlatform succeeds for the
 // current OS/architecture.
 func TestExecutableForPlatform(t *testing.T) {
-	if executable, err := ExecutableForPlatform(runtime.GOOS, runtime.GOARCH, ""); err != nil {
+	logger := logging.NewLogger(logging.LevelError, &bytes.Buffer{})
+	if executable, err := ExecutableForPlatform(runtime.GOOS, runtime.GOARCH, "", logger); err != nil {
 		t.Fatal("unable to extract agent bundle for current platform:", err)
 	} else if err = os.Remove(executable); err != nil {
 		t.Error("unable to remove agent executable:", err)
@@ -44,11 +51,12 @@ func TestExecutableForPlatform(t *testing.T) {
 // TestExecutableForPlatformWithOutputPath tests that ExecutableForPlatform
 // functions correctly when an output path is specified.
 func TestExecutableForPlatformWithOutputPath(t *testing.T) {
+	logger := logging.NewLogger(logging.LevelError, &bytes.Buffer{})
 	// Compute the output path.
 	outputPath := filepath.Join(t.TempDir(), "agent_output")
 
 	// Perform executable extraction.
-	executable, err := ExecutableForPlatform(runtime.GOOS, runtime.GOARCH, outputPath)
+	executable, err := ExecutableForPlatform(runtime.GOOS, runtime.GOARCH, outputPath, logger)
 	if err != nil {
 		t.Fatal("unable to extract agent bundle for current platform:", err)
 	}

--- a/pkg/agent/install.go
+++ b/pkg/agent/install.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 
 	"github.com/google/uuid"
+	"github.com/mutagen-io/mutagen/pkg/must"
 
 	"github.com/mutagen-io/mutagen/pkg/filesystem"
 	"github.com/mutagen-io/mutagen/pkg/logging"
@@ -50,11 +51,11 @@ func install(logger *logging.Logger, transport Transport, prompter string) error
 	if err := prompting.Message(prompter, "Extracting agent..."); err != nil {
 		return fmt.Errorf("unable to message prompter: %w", err)
 	}
-	agentExecutable, err := ExecutableForPlatform(goos, goarch, "")
+	agentExecutable, err := ExecutableForPlatform(goos, goarch, "", logger)
 	if err != nil {
 		return fmt.Errorf("unable to get agent for platform: %w", err)
 	}
-	defer os.Remove(agentExecutable)
+	defer must.OSRemove(agentExecutable, logger)
 
 	// Copy the agent to the remote. We use a unique identifier for the
 	// temporary destination. For Windows remotes, we add a ".exe" suffix, which

--- a/pkg/api/models/forwarding/configuration_test.go
+++ b/pkg/api/models/forwarding/configuration_test.go
@@ -1,11 +1,14 @@
 package forwarding
 
 import (
+	"bytes"
 	"os"
 	"testing"
 
 	"github.com/mutagen-io/mutagen/pkg/encoding"
 	"github.com/mutagen-io/mutagen/pkg/forwarding"
+	"github.com/mutagen-io/mutagen/pkg/logging"
+	"github.com/mutagen-io/mutagen/pkg/must"
 )
 
 const (
@@ -29,6 +32,8 @@ var expectedConfiguration = &forwarding.Configuration{
 
 // TestLoadConfiguration tests loading a YAML-based session configuration.
 func TestLoadConfiguration(t *testing.T) {
+	logger := logging.NewLogger(logging.LevelError, &bytes.Buffer{})
+
 	// Write a valid configuration to a temporary file and defer its cleanup.
 	file, err := os.CreateTemp("", "mutagen_configuration")
 	if err != nil {
@@ -38,7 +43,7 @@ func TestLoadConfiguration(t *testing.T) {
 	} else if err = file.Close(); err != nil {
 		t.Fatal("unable to close temporary file:", err)
 	}
-	defer os.Remove(file.Name())
+	defer must.OSRemove(file.Name(), logger)
 
 	// Attempt to load.
 	yamlConfiguration := &Configuration{}

--- a/pkg/api/models/synchronization/configuration_test.go
+++ b/pkg/api/models/synchronization/configuration_test.go
@@ -1,11 +1,14 @@
 package synchronization
 
 import (
+	"bytes"
 	"os"
 	"testing"
 
 	"github.com/mutagen-io/mutagen/pkg/encoding"
 	"github.com/mutagen-io/mutagen/pkg/filesystem/behavior"
+	"github.com/mutagen-io/mutagen/pkg/logging"
+	"github.com/mutagen-io/mutagen/pkg/must"
 	"github.com/mutagen-io/mutagen/pkg/synchronization"
 	"github.com/mutagen-io/mutagen/pkg/synchronization/core"
 	"github.com/mutagen-io/mutagen/pkg/synchronization/core/ignore"
@@ -75,6 +78,8 @@ var expectedConfiguration = &synchronization.Configuration{
 
 // TestLoadConfiguration tests loading a YAML-based session configuration.
 func TestLoadConfiguration(t *testing.T) {
+	logger := logging.NewLogger(logging.LevelError, &bytes.Buffer{})
+
 	// Write a valid configuration to a temporary file and defer its cleanup.
 	file, err := os.CreateTemp("", "mutagen_configuration")
 	if err != nil {
@@ -84,7 +89,7 @@ func TestLoadConfiguration(t *testing.T) {
 	} else if err = file.Close(); err != nil {
 		t.Fatal("unable to close temporary file:", err)
 	}
-	defer os.Remove(file.Name())
+	defer must.OSRemove(file.Name(), logger)
 
 	// Attempt to load.
 	yamlConfiguration := &Configuration{}

--- a/pkg/daemon/lock_test.go
+++ b/pkg/daemon/lock_test.go
@@ -1,13 +1,18 @@
 package daemon
 
 import (
+	"bytes"
 	"testing"
+
+	"github.com/mutagen-io/mutagen/pkg/logging"
 )
 
 // TestLockCycle tests an acquisition/release cycle of the daemon lock.
 func TestLockCycle(t *testing.T) {
+	logger := logging.NewLogger(logging.LevelError, &bytes.Buffer{})
+
 	// Attempt to acquire the daemon lock.
-	lock, err := AcquireLock()
+	lock, err := AcquireLock(logger)
 	if err != nil {
 		t.Fatal("unable to acquire lock:", err)
 	}

--- a/pkg/daemon/register_others.go
+++ b/pkg/daemon/register_others.go
@@ -4,6 +4,8 @@ package daemon
 
 import (
 	"errors"
+
+	"github.com/mutagen-io/mutagen/pkg/logging"
 )
 
 // RegistrationSupported indicates whether or not daemon registration is
@@ -11,12 +13,12 @@ import (
 const RegistrationSupported = false
 
 // Register performs automatic daemon startup registration.
-func Register() error {
+func Register(logger *logging.Logger) error {
 	return errors.New("daemon registration not supported on this platform")
 }
 
 // Unregister performs automatic daemon startup de-registration.
-func Unregister() error {
+func Unregister(logger *logging.Logger) error {
 	return errors.New("daemon deregistration not supported on this platform")
 }
 

--- a/pkg/daemon/register_windows.go
+++ b/pkg/daemon/register_windows.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/mutagen-io/mutagen/pkg/logging"
 	"golang.org/x/sys/windows/registry"
 )
 
@@ -21,7 +22,7 @@ const (
 )
 
 // Register performs automatic daemon startup registration.
-func Register() error {
+func Register(logger *logging.Logger) error {
 	// Attempt to open the relevant registry path and ensure it's cleaned up
 	// when we're done.
 	key, err := registry.OpenKey(rootKey, runPath, registry.SET_VALUE)
@@ -49,7 +50,7 @@ func Register() error {
 }
 
 // Unregister performs automatic daemon startup de-registration.
-func Unregister() error {
+func Unregister(logger *logging.Logger) error {
 	// Attempt to open the relevant registry path and ensure it's cleaned up
 	// when we're done.
 	key, err := registry.OpenKey(rootKey, runPath, registry.QUERY_VALUE|registry.SET_VALUE)

--- a/pkg/encoding/common.go
+++ b/pkg/encoding/common.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/mutagen-io/mutagen/pkg/filesystem"
+	"github.com/mutagen-io/mutagen/pkg/logging"
 )
 
 // LoadAndUnmarshal provides the underlying loading and unmarshaling
@@ -34,7 +35,7 @@ func LoadAndUnmarshal(path string, unmarshal func([]byte) error) error {
 // the encoding package. It invokes the specified marshaling callback (usually a
 // closure) and writes the result atomically to the specified path. The data is
 // saved with read/write permissions for the user only.
-func MarshalAndSave(path string, marshal func() ([]byte, error)) error {
+func MarshalAndSave(path string, logger *logging.Logger, marshal func() ([]byte, error)) error {
 	// Marshal the message.
 	data, err := marshal()
 	if err != nil {
@@ -42,7 +43,7 @@ func MarshalAndSave(path string, marshal func() ([]byte, error)) error {
 	}
 
 	// Write the file atomically with secure file permissions.
-	if err := filesystem.WriteFileAtomic(path, data, 0600); err != nil {
+	if err := filesystem.WriteFileAtomic(path, data, 0600, logger); err != nil {
 		return fmt.Errorf("unable to write message data: %w", err)
 	}
 

--- a/pkg/encoding/protobuf.go
+++ b/pkg/encoding/protobuf.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/mutagen-io/mutagen/pkg/logging"
 	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/proto"
 
@@ -42,8 +43,8 @@ func LoadAndUnmarshalProtobuf(path string, message proto.Message) error {
 
 // MarshalAndSaveProtobuf marshals the specified Protocol Buffers message and
 // saves it to the specified path.
-func MarshalAndSaveProtobuf(path string, message proto.Message) error {
-	return MarshalAndSave(path, func() ([]byte, error) {
+func MarshalAndSaveProtobuf(path string, message proto.Message, logger *logging.Logger) error {
+	return MarshalAndSave(path, logger, func() ([]byte, error) {
 		return proto.Marshal(message)
 	})
 }

--- a/pkg/encoding/protobuf_test.go
+++ b/pkg/encoding/protobuf_test.go
@@ -5,12 +5,16 @@ import (
 	"os"
 	"testing"
 
+	"github.com/mutagen-io/mutagen/pkg/logging"
+	"github.com/mutagen-io/mutagen/pkg/must"
 	"github.com/mutagen-io/mutagen/pkg/url"
 )
 
 // TestProtocolBuffersCycle tests a Protocol Buffers marshal/save/load/unmarshal
 // cycle.
 func TestProtocolBuffersCycle(t *testing.T) {
+	logger := logging.NewLogger(logging.LevelError, &bytes.Buffer{})
+
 	// Create an empty temporary file and defer its cleanup.
 	file, err := os.CreateTemp("", "mutagen_encoding")
 	if err != nil {
@@ -18,7 +22,7 @@ func TestProtocolBuffersCycle(t *testing.T) {
 	} else if err = file.Close(); err != nil {
 		t.Fatal("unable to close temporary file:", err)
 	}
-	defer os.Remove(file.Name())
+	defer must.OSRemove(file.Name(), logger)
 
 	// Create a Protocol Buffers message that we can test with.
 	message := &url.URL{
@@ -28,7 +32,7 @@ func TestProtocolBuffersCycle(t *testing.T) {
 		Port:     1776,
 		Path:     "/by/land/or/by/sea",
 	}
-	if err := MarshalAndSaveProtobuf(file.Name(), message); err != nil {
+	if err := MarshalAndSaveProtobuf(file.Name(), message, logger); err != nil {
 		t.Fatal("unable to marshal and save Protocol Buffers message:", err)
 	}
 

--- a/pkg/encoding/yaml_test.go
+++ b/pkg/encoding/yaml_test.go
@@ -1,8 +1,12 @@
 package encoding
 
 import (
+	"bytes"
 	"os"
 	"testing"
+
+	"github.com/mutagen-io/mutagen/pkg/logging"
+	"github.com/mutagen-io/mutagen/pkg/must"
 )
 
 // testMessageYAML is a test structure to use for encoding tests using YAML.
@@ -29,6 +33,8 @@ section:
 // TestLoadAndUnmarshalYAML tests that loading and unmarshaling YAML data
 // succeeds.
 func TestLoadAndUnmarshalYAML(t *testing.T) {
+	logger := logging.NewLogger(logging.LevelError, &bytes.Buffer{})
+
 	// Write the test YAML to a temporary file and defer its cleanup.
 	file, err := os.CreateTemp("", "mutagen_encoding")
 	if err != nil {
@@ -38,7 +44,7 @@ func TestLoadAndUnmarshalYAML(t *testing.T) {
 	} else if err = file.Close(); err != nil {
 		t.Fatal("unable to close temporary file:", err)
 	}
-	defer os.Remove(file.Name())
+	defer must.OSRemove(file.Name(), logger)
 
 	// Attempt to load and unmarshal.
 	value := &testMessageYAML{}

--- a/pkg/filesystem/atomic.go
+++ b/pkg/filesystem/atomic.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/mutagen-io/mutagen/pkg/logging"
+	"github.com/mutagen-io/mutagen/pkg/must"
 )
 
 const (
@@ -15,7 +18,7 @@ const (
 // WriteFileAtomic writes a file to disk in an atomic fashion by using an
 // intermediate temporary file that is swapped in place using a rename
 // operation.
-func WriteFileAtomic(path string, data []byte, permissions os.FileMode) error {
+func WriteFileAtomic(path string, data []byte, permissions os.FileMode, logger *logging.Logger) error {
 	// Create a temporary file. The os package already uses secure permissions
 	// for creating temporary files, so we don't need to change them.
 	temporary, err := os.CreateTemp(filepath.Dir(path), atomicWriteTemporaryNamePrefix)
@@ -25,26 +28,26 @@ func WriteFileAtomic(path string, data []byte, permissions os.FileMode) error {
 
 	// Write data.
 	if _, err = temporary.Write(data); err != nil {
-		temporary.Close()
-		os.Remove(temporary.Name())
+		must.Close(temporary, logger)
+		must.OSRemove(temporary.Name(), logger)
 		return fmt.Errorf("unable to write data to temporary file: %w", err)
 	}
 
 	// Close out the file.
 	if err = temporary.Close(); err != nil {
-		os.Remove(temporary.Name())
+		must.OSRemove(temporary.Name(), logger)
 		return fmt.Errorf("unable to close temporary file: %w", err)
 	}
 
 	// Set the file's permissions.
 	if err = os.Chmod(temporary.Name(), permissions); err != nil {
-		os.Remove(temporary.Name())
+		must.OSRemove(temporary.Name(), logger)
 		return fmt.Errorf("unable to change file permissions: %w", err)
 	}
 
 	// Rename the file.
 	if err = Rename(nil, temporary.Name(), nil, path, true); err != nil {
-		os.Remove(temporary.Name())
+		must.OSRemove(temporary.Name(), logger)
 		return fmt.Errorf("unable to rename file: %w", err)
 	}
 

--- a/pkg/filesystem/atomic_test.go
+++ b/pkg/filesystem/atomic_test.go
@@ -5,15 +5,21 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/mutagen-io/mutagen/pkg/logging"
 )
 
 func TestWriteFileAtomicNonExistentDirectory(t *testing.T) {
-	if WriteFileAtomic("/does/not/exist", []byte{}, 0600) == nil {
+	logger := logging.NewLogger(logging.LevelError, &bytes.Buffer{})
+
+	if WriteFileAtomic("/does/not/exist", []byte{}, 0600, logger) == nil {
 		t.Error("atomic file write did not fail for non-existent path")
 	}
 }
 
 func TestWriteFileAtomic(t *testing.T) {
+	logger := logging.NewLogger(logging.LevelError, &bytes.Buffer{})
+
 	// Compute the target path.
 	target := filepath.Join(t.TempDir(), "file")
 
@@ -21,7 +27,7 @@ func TestWriteFileAtomic(t *testing.T) {
 	contents := []byte{0, 1, 2, 3, 4, 5, 6}
 
 	// Attempt to write to a temporary file.
-	if err := WriteFileAtomic(target, contents, 0600); err != nil {
+	if err := WriteFileAtomic(target, contents, 0600, logger); err != nil {
 		t.Fatal("atomic file write failed:", err)
 	}
 

--- a/pkg/filesystem/interrupt_posix.go
+++ b/pkg/filesystem/interrupt_posix.go
@@ -5,6 +5,7 @@ package filesystem
 import (
 	"io"
 
+	"github.com/mutagen-io/mutagen/pkg/logging"
 	"golang.org/x/sys/unix"
 
 	"github.com/mutagen-io/mutagen/pkg/filesystem/internal/syscall"
@@ -56,6 +57,15 @@ func seekConsideringEINTR(file int, offset int64, whence int) (int64, error) {
 // is the same policy adopted by the Go standard library and runtime.
 func closeConsideringEINTR(file int) error {
 	return unix.Close(file)
+}
+
+// mustCloseConsideringEINTR calls closeConsideringEINTR and logs if there is an
+// error.
+func mustCloseConsideringEINTR(file int, logger *logging.Logger) {
+	err := unix.Close(file)
+	if err != nil {
+		logger.Warnf("Unable to close considering EINTR file %d; %s", file, err.Error())
+	}
 }
 
 // mkdiratRetryingOnEINTR is a wrapper around the mkdirat system call that

--- a/pkg/filesystem/open_windows_test.go
+++ b/pkg/filesystem/open_windows_test.go
@@ -1,15 +1,19 @@
 package filesystem
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/mutagen-io/mutagen/pkg/logging"
 )
 
 // TestOpenLongPath verifies that calling Open succeeds on a directory whose
 // path length exceeds the default path length limit on Windows.
 func TestOpenLongPath(t *testing.T) {
+	logger := logging.NewLogger(logging.LevelError, &bytes.Buffer{})
 	// Create a directory (in a temporary directory that will be automatically
 	// removed) with a name that will exceed the Windows path length limit.
 	longDirectoryName := strings.Repeat("d", windowsLongPathTestingLength)
@@ -19,7 +23,7 @@ func TestOpenLongPath(t *testing.T) {
 	}
 
 	// Attempt to open the directory and ensure doing so succeeds.
-	directory, _, err := Open(longtemporaryDirectoryPath, false)
+	directory, _, err := Open(longtemporaryDirectoryPath, false, logger)
 	if err != nil {
 		t.Fatal("unable to open directory with long path:", err)
 	}

--- a/pkg/filesystem/visibility_test.go
+++ b/pkg/filesystem/visibility_test.go
@@ -1,18 +1,24 @@
 package filesystem
 
 import (
+	"bytes"
 	"os"
 	"testing"
+
+	"github.com/mutagen-io/mutagen/pkg/logging"
+	"github.com/mutagen-io/mutagen/pkg/must"
 )
 
 func TestMarkHidden(t *testing.T) {
+	logger := logging.NewLogger(logging.LevelError, &bytes.Buffer{})
+
 	// Create a temporary file and defer its removal.
 	hiddenFile, err := os.CreateTemp("", ".mutagen_filesystem_hidden")
 	if err != nil {
 		t.Fatal("unable to create temporary hiddenFile file:", err)
 	}
-	hiddenFile.Close()
-	defer os.Remove(hiddenFile.Name())
+	must.Close(hiddenFile, logger)
+	defer must.OSRemove(hiddenFile.Name(), logger)
 
 	// Ensure that we can mark it as hidden.
 	if err := MarkHidden(hiddenFile.Name()); err != nil {

--- a/pkg/filesystem/watching/watch_test.go
+++ b/pkg/filesystem/watching/watch_test.go
@@ -1,11 +1,15 @@
 package watching
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
 	"time"
+
+	"github.com/mutagen-io/mutagen/pkg/logging"
+	"github.com/mutagen-io/mutagen/pkg/must"
 )
 
 const (
@@ -47,6 +51,8 @@ func TestRecursiveWatcher(t *testing.T) {
 		t.Skip()
 	}
 
+	logger := logging.NewLogger(logging.LevelError, &bytes.Buffer{})
+
 	// Create a temporary directory (that will be automatically removed).
 	directory := t.TempDir()
 
@@ -55,7 +61,7 @@ func TestRecursiveWatcher(t *testing.T) {
 	if err != nil {
 		t.Fatal("unable to establish watch:", err)
 	}
-	defer watcher.Terminate()
+	defer must.Terminate(watcher, logger)
 
 	// Create a subdirectory.
 	subdirectoryRelative := "subdirectory"
@@ -101,6 +107,7 @@ func TestNonRecursiveWatcher(t *testing.T) {
 	if !NonRecursiveWatchingSupported {
 		t.Skip()
 	}
+	logger := logging.NewLogger(logging.LevelError, &bytes.Buffer{})
 
 	// Create a temporary directory (that will be automatically removed).
 	directory := t.TempDir()
@@ -111,7 +118,7 @@ func TestNonRecursiveWatcher(t *testing.T) {
 		t.Fatal("unable to create watcher:", err)
 	}
 	watcher.Watch(directory)
-	defer watcher.Terminate()
+	defer must.Terminate(watcher, logger)
 
 	// Create a subdirectory.
 	subdirectoryPath := filepath.Join(directory, "subdirectory")

--- a/pkg/forwarding/connect.go
+++ b/pkg/forwarding/connect.go
@@ -41,6 +41,10 @@ func connect(
 	configuration *Configuration,
 	source bool,
 ) (Endpoint, error) {
+
+	// Added trace to bypass "unused parameter `session` warning
+	logger.Tracef("Connecting to %s for session %s", url.String(), session)
+
 	// Local the appropriate protocol handler.
 	handler, ok := ProtocolHandlers[url.Protocol]
 	if !ok {

--- a/pkg/forwarding/endpoint/remote/client.go
+++ b/pkg/forwarding/endpoint/remote/client.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mutagen-io/mutagen/pkg/forwarding"
 	"github.com/mutagen-io/mutagen/pkg/logging"
 	"github.com/mutagen-io/mutagen/pkg/multiplexing"
+	"github.com/mutagen-io/mutagen/pkg/must"
 )
 
 // client is a client for a remote forwarding.Endpoint and implements
@@ -52,7 +53,7 @@ func NewEndpoint(
 	var initializationSuccessful bool
 	defer func() {
 		if !initializationSuccessful {
-			carrier.Close()
+			must.Close(carrier, logger)
 		}
 	}()
 
@@ -83,7 +84,7 @@ func NewEndpoint(
 	initializationSuccessful = true
 
 	// Multiplex the carrier.
-	multiplexer := multiplexing.Multiplex(carrier, false, nil)
+	multiplexer := multiplexing.Multiplex(carrier, false, nil, logger)
 
 	// Create a channel to monitor for transport errors and a Goroutine to
 	// populate it.

--- a/pkg/forwarding/protocols/docker/protocol.go
+++ b/pkg/forwarding/protocols/docker/protocol.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mutagen-io/mutagen/pkg/forwarding"
 	"github.com/mutagen-io/mutagen/pkg/forwarding/endpoint/remote"
 	"github.com/mutagen-io/mutagen/pkg/logging"
+	"github.com/mutagen-io/mutagen/pkg/must"
 	urlpkg "github.com/mutagen-io/mutagen/pkg/url"
 	forwardingurlpkg "github.com/mutagen-io/mutagen/pkg/url/forwarding"
 )
@@ -38,6 +39,10 @@ func (p *protocolHandler) Connect(
 	configuration *forwarding.Configuration,
 	source bool,
 ) (forwarding.Endpoint, error) {
+
+	// Added trace to bypass "unused parameter `session` warning
+	logger.Tracef("Connecting to %s  for session %s", url.String(), session)
+
 	// Verify that the URL is of the correct kind and protocol.
 	if url.Kind != urlpkg.Kind_Forwarding {
 		panic("non-forwarding URL dispatched to forwarding protocol handler")
@@ -71,7 +76,7 @@ func (p *protocolHandler) Connect(
 		case results <- dialResult{stream, err}:
 		case <-ctx.Done():
 			if stream != nil {
-				stream.Close()
+				must.Close(stream, logger)
 			}
 		}
 	}()

--- a/pkg/forwarding/protocols/ssh/protocol.go
+++ b/pkg/forwarding/protocols/ssh/protocol.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mutagen-io/mutagen/pkg/forwarding"
 	"github.com/mutagen-io/mutagen/pkg/forwarding/endpoint/remote"
 	"github.com/mutagen-io/mutagen/pkg/logging"
+	"github.com/mutagen-io/mutagen/pkg/must"
 	urlpkg "github.com/mutagen-io/mutagen/pkg/url"
 	forwardingurlpkg "github.com/mutagen-io/mutagen/pkg/url/forwarding"
 )
@@ -38,6 +39,10 @@ func (p *protocolHandler) Connect(
 	configuration *forwarding.Configuration,
 	source bool,
 ) (forwarding.Endpoint, error) {
+
+	// Added trace to bypass "unused parameter `session` warning
+	logger.Tracef("Connecting to %s for session %s", url.String(), session)
+
 	// Verify that the URL is of the correct kind and protocol.
 	if url.Kind != urlpkg.Kind_Forwarding {
 		panic("non-forwarding URL dispatched to forwarding protocol handler")
@@ -71,7 +76,7 @@ func (p *protocolHandler) Connect(
 		case results <- dialResult{stream, err}:
 		case <-ctx.Done():
 			if stream != nil {
-				stream.Close()
+				must.Close(stream, logger)
 			}
 		}
 	}()

--- a/pkg/housekeeping/housekeep_test.go
+++ b/pkg/housekeeping/housekeep_test.go
@@ -1,25 +1,32 @@
 package housekeeping
 
 import (
+	"bytes"
 	"testing"
+
+	"github.com/mutagen-io/mutagen/pkg/logging"
 )
 
 // TestHousekeep tests that Housekeep succeeds without panicking.
 func TestHousekeep(_ *testing.T) {
-	Housekeep()
+	logger := logging.NewLogger(logging.LevelError, &bytes.Buffer{})
+	Housekeep(logger)
 }
 
 // TestHousekeepAgents tests that housekeepAgents succeeds without panicking.
 func TestHousekeepAgents(_ *testing.T) {
-	housekeepAgents()
+	logger := logging.NewLogger(logging.LevelError, &bytes.Buffer{})
+	housekeepAgents(logger)
 }
 
 // TestHousekeepCaches tests that housekeepCaches succeeds without panicking.
 func TestHousekeepCaches(_ *testing.T) {
-	housekeepCaches()
+	logger := logging.NewLogger(logging.LevelError, &bytes.Buffer{})
+	housekeepCaches(logger)
 }
 
 // TestHousekeepStaging tests that housekeepStaging succeeds without panicking.
 func TestHousekeepStaging(_ *testing.T) {
-	housekeepStaging()
+	logger := logging.NewLogger(logging.LevelError, &bytes.Buffer{})
+	housekeepStaging(logger)
 }

--- a/pkg/integration/internal_api_test.go
+++ b/pkg/integration/internal_api_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -12,6 +13,8 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/mutagen-io/mutagen/pkg/logging"
+	"github.com/mutagen-io/mutagen/pkg/must"
 
 	"github.com/mutagen-io/mutagen/pkg/forwarding"
 	"github.com/mutagen-io/mutagen/pkg/forwarding/endpoint/local"
@@ -422,6 +425,8 @@ func init() {
 }
 
 func TestForwardingToHTTPDemo(t *testing.T) {
+	logger := logging.NewLogger(logging.LevelError, &bytes.Buffer{})
+
 	// If Docker test support isn't available, then skip this test.
 	if os.Getenv("MUTAGEN_TEST_DOCKER") != "true" {
 		t.Skip()
@@ -480,7 +485,7 @@ func TestForwardingToHTTPDemo(t *testing.T) {
 		if err != nil {
 			return fmt.Errorf("unable to perform HTTP GET: %w", err)
 		}
-		defer response.Body.Close()
+		defer must.Close(response.Body, logger)
 
 		// Read the full body.
 		message, err := io.ReadAll(response.Body)

--- a/pkg/ipc/ipc_posix.go
+++ b/pkg/ipc/ipc_posix.go
@@ -7,6 +7,9 @@ import (
 	"fmt"
 	"net"
 	"os"
+
+	"github.com/mutagen-io/mutagen/pkg/logging"
+	"github.com/mutagen-io/mutagen/pkg/must"
 )
 
 // DialContext attempts to establish an IPC connection, timing out if the
@@ -21,7 +24,7 @@ func DialContext(ctx context.Context, path string) (net.Conn, error) {
 }
 
 // NewListener creates a new IPC listener.
-func NewListener(path string) (net.Listener, error) {
+func NewListener(path string, logger *logging.Logger) (net.Listener, error) {
 	// Create the listener.
 	listener, err := net.Listen("unix", path)
 	if err != nil {
@@ -31,7 +34,7 @@ func NewListener(path string) (net.Listener, error) {
 	// Explicitly set socket permissions. Unfortunately we can't do this
 	// atomically on socket creation, but we can do it quickly.
 	if err := os.Chmod(path, 0600); err != nil {
-		listener.Close()
+		must.Close(listener, logger)
 		return nil, fmt.Errorf("unable to set socket permissions: %w", err)
 	}
 

--- a/pkg/must/must.go
+++ b/pkg/must/must.go
@@ -1,0 +1,176 @@
+package must
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"os"
+
+	"github.com/mutagen-io/mutagen/pkg/logging"
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/proto"
+)
+
+func Fprint(w io.Writer, logger *logging.Logger, a ...any) {
+	s := fmt.Sprint(a...)
+	n, err := fmt.Fprint(w, s)
+	if err != nil {
+		logger.Warnf("Unable to Fprint '%s'; %s", s, err.Error())
+	}
+	if n < len(s) {
+		logger.Warnf("Unable to Fprint all of '%s'; printed only %d of %d bytes", s, n, len(s))
+	}
+}
+
+func Close(c io.Closer, logger *logging.Logger) {
+	err := c.Close()
+	if err != nil {
+		logger.Warnf("Unable to close: %s", err.Error())
+	}
+}
+
+func Serve(ws interface{ Serve(net.Listener) error }, nl net.Listener, logger *logging.Logger) {
+	err := ws.Serve(nl)
+	if err != nil {
+		logger.Warnf("Unable to serve '%s': %s", nl.Addr(), err.Error())
+	}
+}
+
+func WriteString(ws interface{ WriteString(string) (int, error) }, s string, logger *logging.Logger) {
+	n, err := ws.WriteString(s)
+	if err != nil {
+		logger.Warnf("Unable to write string '%s': %s", s, err.Error())
+	}
+	if n < len(s) {
+		logger.Warnf("Unable to write all of string '%s'; only wrote %d of %d bytes", s, n, len(s))
+	}
+}
+
+func CloseWrite(cw interface{ CloseWrite() error }, logger *logging.Logger) {
+	err := cw.CloseWrite()
+	if err != nil {
+		logger.Warnf("Unable to CloseWrite: %s", err.Error())
+	}
+}
+
+func Signal(s interface{ Signal(os.Signal) error }, sig os.Signal, logger *logging.Logger) {
+	err := s.Signal(sig)
+	if err != nil {
+		logger.Warnf("Unable to signal '%s': %s", sig, err.Error())
+	}
+}
+
+func Terminate(s interface{ Terminate() error }, logger *logging.Logger) {
+	err := s.Terminate()
+	if err != nil {
+		logger.Warnf("Unable to terminate: %s", err.Error())
+	}
+}
+
+func Finalize(s interface{ Finalize() error }, logger *logging.Logger) {
+	err := s.Finalize()
+	if err != nil {
+		logger.Warnf("Unable to finalize: %s", err.Error())
+	}
+}
+
+func Remove(r interface{ Remove(string) error }, path string, logger *logging.Logger) {
+	err := r.Remove(path)
+	if err != nil {
+		logger.Warnf("Unable to remove '%s': %s", path, err.Error())
+	}
+}
+
+func Unlock(locker interface{ Unlock() error }, logger *logging.Logger) {
+	err := locker.Unlock()
+	if err != nil {
+		logger.Warnf("Unable to unlock locker: %s", err.Error())
+	}
+}
+
+func OSRemove(name string, logger *logging.Logger) {
+	err := os.Remove(name)
+	if err != nil {
+		logger.Warnf("Unable to remove '%s': %s", name, err.Error())
+	}
+}
+
+func Truncate(t interface{ Truncate(int64) error }, size int64, logger *logging.Logger) {
+	err := t.Truncate(size)
+	if err != nil {
+		logger.Warnf("Unable to truncate to size %d: %s", size, err.Error())
+	}
+}
+
+func Kill(s interface{ Kill() error }, logger *logging.Logger) {
+	err := s.Kill()
+	if err != nil {
+		logger.Warnf("Unable to Kill: %s", err.Error())
+	}
+}
+
+func IOCopy(dst io.Writer, src io.Reader, logger *logging.Logger) {
+	_, err := io.Copy(dst, src)
+	if err != nil {
+		logger.Warnf("Unable to copy from source to destination: %s", err.Error())
+	}
+}
+
+func CommandHelp(c *cobra.Command, logger *logging.Logger) {
+	err := c.Help()
+	if err != nil {
+		logger.Warnf("Unable to help: %s", err.Error())
+	}
+}
+
+func RemoveFile(rf interface{ RemoveFile(string) error }, name string, logger *logging.Logger) {
+	err := rf.RemoveFile(name)
+	if err != nil {
+		logger.Warnf("Unable to remove file '%s': %s", name, err.Error())
+	}
+}
+
+func Shutdown(sd interface{ Shutdown() error }, logger *logging.Logger) {
+	err := sd.Shutdown()
+	if err != nil {
+		logger.Warnf("Unable to shutdown: %s", err.Error())
+	}
+}
+
+func Flush(sd interface{ Flush() error }, logger *logging.Logger) {
+	err := sd.Flush()
+	if err != nil {
+		logger.Warnf("Unable to flush: %s", err.Error())
+	}
+}
+
+func Release(r interface{ Release() error }, logger *logging.Logger) {
+	err := r.Release()
+	if err != nil {
+		logger.Warnf("Unable to release: %s", err.Error())
+	}
+}
+
+func ProtoEncode(e interface {
+	Encode(message proto.Message) error
+}, message proto.Message, logger *logging.Logger) {
+	err := e.Encode(message)
+	if err != nil {
+		logger.Warnf("Unable to proto encode %s: %s", message, err.Error())
+	}
+}
+
+func Encode(e interface {
+	Encode(e any) error
+}, value any, logger *logging.Logger) {
+	err := e.Encode(value)
+	if err != nil {
+		logger.Warnf("Unable to encode %v: %s", value, err.Error())
+	}
+}
+
+func Succeed(err error, task string, logger *logging.Logger) {
+	if err != nil {
+		logger.Warnf("Unable to succeed at %s; %s", task, err.Error())
+	}
+}

--- a/pkg/must/must_windows.go
+++ b/pkg/must/must_windows.go
@@ -1,0 +1,14 @@
+//go:build:windows
+package must
+
+import (
+	"github.com/mutagen-io/mutagen/pkg/logging"
+	"golang.org/x/sys/windows"
+)
+
+func CloseWindowsHandle(wh windows.Handle, logger *logging.Logger) {
+	err := windows.CloseHandle(wh)
+	if err != nil {
+		logger.Warnf("Unable to close handle %d: %s", wh, err.Error())
+	}
+}

--- a/pkg/prompting/registry.go
+++ b/pkg/prompting/registry.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/mutagen-io/mutagen/pkg/identifier"
+	"github.com/mutagen-io/mutagen/pkg/logging"
 )
 
 // registryLock is the lock on the global prompter registry.
@@ -119,6 +120,14 @@ func Message(identifier, message string) error {
 
 	// Success.
 	return nil
+}
+
+// MustMessage invokes Message and logs any error received
+func MustMessage(identifier, prompt string, logger *logging.Logger) {
+	err := Message(identifier, prompt)
+	if err != nil {
+		logger.Warnf("Unable to prompt '%s' with message '%s'; %s", identifier, prompt, err.Error())
+	}
 }
 
 // Prompt invokes the Prompt method on a prompter in the global registry.

--- a/pkg/sidecar/permissions.go
+++ b/pkg/sidecar/permissions.go
@@ -4,24 +4,26 @@ import (
 	"fmt"
 
 	"github.com/mutagen-io/mutagen/pkg/filesystem"
+	"github.com/mutagen-io/mutagen/pkg/logging"
+	"github.com/mutagen-io/mutagen/pkg/must"
 )
 
 // SetVolumeOwnershipAndPermissionsIfEmpty will set the ownership and
 // permissions on a sidecar volume if (and only if) the volume is empty.
-func SetVolumeOwnershipAndPermissionsIfEmpty(name string, ownership *filesystem.OwnershipSpecification, mode filesystem.Mode) error {
+func SetVolumeOwnershipAndPermissionsIfEmpty(name string, ownership *filesystem.OwnershipSpecification, mode filesystem.Mode, logger *logging.Logger) error {
 	// Open the volumes directory and defer its closure.
-	volumes, _, err := filesystem.OpenDirectory(volumeMountParent, false)
+	volumes, _, err := filesystem.OpenDirectory(volumeMountParent, false, logger)
 	if err != nil {
 		return fmt.Errorf("unable to open volumes directory: %w", err)
 	}
-	defer volumes.Close()
+	defer must.Close(volumes, logger)
 
 	// Open the volume mount point and defer its closure.
-	volume, err := volumes.OpenDirectory(name)
+	volume, err := volumes.OpenDirectory(name, logger)
 	if err != nil {
 		return fmt.Errorf("unable to open volume root: %w", err)
 	}
-	defer volume.Close()
+	defer must.Close(volume, logger)
 
 	// Check if the volume is empty. If not, then we're done.
 	if contentNames, err := volume.ReadContentNames(); err != nil {

--- a/pkg/synchronization/core/testing_provider_test.go
+++ b/pkg/synchronization/core/testing_provider_test.go
@@ -9,6 +9,9 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+
+	"github.com/mutagen-io/mutagen/pkg/logging"
+	"github.com/mutagen-io/mutagen/pkg/must"
 )
 
 // testingContentMap is an in-memory content map type used by testProvider.
@@ -25,6 +28,8 @@ type testingProvider struct {
 	hasherLock sync.Mutex
 	// hasher is the hasher to use when verifying content.
 	hasher hash.Hash
+
+	logger *logging.Logger
 }
 
 // Provide implements the Provider interface for testProvider.
@@ -56,9 +61,9 @@ func (p *testingProvider) Provide(path string, digest []byte) (string, error) {
 
 	// Write content.
 	_, err = file.Write(content)
-	file.Close()
+	must.Close(file, p.logger)
 	if err != nil {
-		os.Remove(file.Name())
+		must.OSRemove(file.Name(), p.logger)
 		return "", fmt.Errorf("unable to write file contents: %w", err)
 	}
 

--- a/pkg/synchronization/core/transition_test.go
+++ b/pkg/synchronization/core/transition_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/mutagen-io/mutagen/pkg/filesystem/behavior"
+	"github.com/mutagen-io/mutagen/pkg/logging"
 	mutagenignore "github.com/mutagen-io/mutagen/pkg/synchronization/core/ignore/mutagen"
 )
 
@@ -51,6 +53,8 @@ func testingNWildcardEntries(n uint) []*Entry {
 
 // TestTransition tests Transition.
 func TestTransition(t *testing.T) {
+	logger := logging.NewLogger(logging.LevelError, &bytes.Buffer{})
+
 	// Create contexts to use for tests.
 	backgroundCtx := context.Background()
 	cancelledCtx, cancel := context.WithCancel(backgroundCtx)
@@ -705,6 +709,7 @@ func TestTransition(t *testing.T) {
 				baselineContentMap: test.baselineContentMap,
 				tweak:              test.tweak,
 				untweak:            test.untweak,
+				logger:             logger,
 			}
 			root, err := generator.generate()
 			if err != nil {
@@ -741,6 +746,7 @@ func TestTransition(t *testing.T) {
 				behavior.ProbeMode_ProbeModeProbe,
 				test.symbolicLinkMode,
 				PermissionsMode_PermissionsModePortable,
+				logger,
 			)
 			if err != nil {
 				t.Errorf("%s: unable to perform scan of baseline on %s filesystem: %v",
@@ -776,6 +782,7 @@ func TestTransition(t *testing.T) {
 				nil,
 				snapshot.DecomposesUnicode,
 				provider,
+				logger,
 			)
 
 			// Check results.

--- a/pkg/synchronization/protocols/docker/protocol.go
+++ b/pkg/synchronization/protocols/docker/protocol.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mutagen-io/mutagen/pkg/agent"
 	"github.com/mutagen-io/mutagen/pkg/agent/transport/docker"
 	"github.com/mutagen-io/mutagen/pkg/logging"
+	"github.com/mutagen-io/mutagen/pkg/must"
 	"github.com/mutagen-io/mutagen/pkg/synchronization"
 	"github.com/mutagen-io/mutagen/pkg/synchronization/endpoint/remote"
 	urlpkg "github.com/mutagen-io/mutagen/pkg/url"
@@ -64,7 +65,7 @@ func (h *protocolHandler) Connect(
 		case results <- dialResult{stream, err}:
 		case <-ctx.Done():
 			if stream != nil {
-				stream.Close()
+				must.Close(stream, logger)
 			}
 		}
 	}()

--- a/pkg/synchronization/protocols/ssh/protocol.go
+++ b/pkg/synchronization/protocols/ssh/protocol.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mutagen-io/mutagen/pkg/agent"
 	"github.com/mutagen-io/mutagen/pkg/agent/transport/ssh"
 	"github.com/mutagen-io/mutagen/pkg/logging"
+	"github.com/mutagen-io/mutagen/pkg/must"
 	"github.com/mutagen-io/mutagen/pkg/synchronization"
 	"github.com/mutagen-io/mutagen/pkg/synchronization/endpoint/remote"
 	urlpkg "github.com/mutagen-io/mutagen/pkg/url"
@@ -64,7 +65,7 @@ func (h *protocolHandler) Connect(
 		case results <- dialResult{stream, err}:
 		case <-ctx.Done():
 			if stream != nil {
-				stream.Close()
+				must.Close(stream, logger)
 			}
 		}
 	}()

--- a/scripts/build.go
+++ b/scripts/build.go
@@ -20,6 +20,8 @@ import (
 	"github.com/mutagen-io/mutagen/cmd"
 
 	"github.com/mutagen-io/mutagen/pkg/agent"
+	"github.com/mutagen-io/mutagen/pkg/logging"
+	"github.com/mutagen-io/mutagen/pkg/must"
 	"github.com/mutagen-io/mutagen/pkg/mutagen"
 )
 
@@ -386,9 +388,10 @@ type ArchiveBuilder struct {
 	compressor *gzip.Writer
 	archiver   *tar.Writer
 	copyBuffer []byte
+	logger     *logging.Logger
 }
 
-func NewArchiveBuilder(bundlePath string) (*ArchiveBuilder, error) {
+func NewArchiveBuilder(bundlePath string, logger *logging.Logger) (*ArchiveBuilder, error) {
 	// Open the underlying file.
 	file, err := os.Create(bundlePath)
 	if err != nil {
@@ -398,7 +401,7 @@ func NewArchiveBuilder(bundlePath string) (*ArchiveBuilder, error) {
 	// Create the compressor.
 	compressor, err := gzip.NewWriterLevel(file, gzip.BestCompression)
 	if err != nil {
-		file.Close()
+		must.Close(file, logger)
 		return nil, fmt.Errorf("unable to create compressor: %w", err)
 	}
 
@@ -408,17 +411,18 @@ func NewArchiveBuilder(bundlePath string) (*ArchiveBuilder, error) {
 		compressor: compressor,
 		archiver:   tar.NewWriter(compressor),
 		copyBuffer: make([]byte, archiveBuilderCopyBufferSize),
+		logger:     logger,
 	}, nil
 }
 
 func (b *ArchiveBuilder) Close() error {
 	// Close in the necessary order to trigger flushes.
 	if err := b.archiver.Close(); err != nil {
-		b.compressor.Close()
-		b.file.Close()
+		must.Close(b.compressor, b.logger)
+		must.Close(b.file, b.logger)
 		return fmt.Errorf("unable to close archiver: %w", err)
 	} else if err := b.compressor.Close(); err != nil {
-		b.file.Close()
+		must.Close(b.file, b.logger)
 		return fmt.Errorf("unable to close compressor: %w", err)
 	} else if err := b.file.Close(); err != nil {
 		return fmt.Errorf("unable to close file: %w", err)
@@ -439,7 +443,7 @@ func (b *ArchiveBuilder) Add(name, path string, mode int64) error {
 	if err != nil {
 		return fmt.Errorf("unable to open file: %w", err)
 	}
-	defer file.Close()
+	defer must.Close(file, b.logger)
 
 	// Compute its size.
 	stat, err := file.Stat()
@@ -470,13 +474,13 @@ func (b *ArchiveBuilder) Add(name, path string, mode int64) error {
 
 // copyFile copies the contents at sourcePath to a newly created file at
 // destinationPath that inherits the permissions of sourcePath.
-func copyFile(sourcePath, destinationPath string) error {
+func copyFile(sourcePath, destinationPath string, logger *logging.Logger) error {
 	// Open the source file and defer its closure.
 	source, err := os.Open(sourcePath)
 	if err != nil {
 		return fmt.Errorf("unable to open source file: %w", err)
 	}
-	defer source.Close()
+	defer must.Close(source, logger)
 
 	// Grab source file metadata.
 	metadata, err := source.Stat()
@@ -485,7 +489,7 @@ func copyFile(sourcePath, destinationPath string) error {
 	}
 
 	// Remove the destination.
-	os.Remove(destinationPath)
+	must.OSRemove(destinationPath, logger)
 
 	// Create the destination file and defer its closure. We open with exclusive
 	// creation flags to ensure that we're the ones creating the file so that
@@ -494,7 +498,7 @@ func copyFile(sourcePath, destinationPath string) error {
 	if err != nil {
 		return fmt.Errorf("unable to create destination file: %w", err)
 	}
-	defer destination.Close()
+	defer must.Close(destination, logger)
 
 	// Copy contents.
 	if count, err := io.Copy(destination, source); err != nil {
@@ -530,6 +534,8 @@ this script is operated in a non-interactive mode.
 
 // build is the primary entry point.
 func build() error {
+	logger := logging.NewLogger(logging.LevelError, os.Stderr)
+
 	// Parse command line arguments.
 	flagSet := pflag.NewFlagSet("build", pflag.ContinueOnError)
 	flagSet.SetOutput(io.Discard)
@@ -540,7 +546,7 @@ func build() error {
 	flagSet.BoolVar(&enableSSPLEnhancements, "sspl", false, "enable SSPL-licensed enhancements")
 	if err := flagSet.Parse(os.Args[1:]); err != nil {
 		if err == pflag.ErrHelp {
-			fmt.Fprint(os.Stdout, usage)
+			must.Fprint(os.Stdout, logger, usage)
 			return nil
 		} else {
 			return fmt.Errorf("unable to parse command line: %w", err)
@@ -673,14 +679,14 @@ func build() error {
 	// Build the agent bundle.
 	log.Println("Building agent bundle...")
 	agentBundlePath := filepath.Join(buildPath, agent.BundleName)
-	agentBundleBuilder, err := NewArchiveBuilder(agentBundlePath)
+	agentBundleBuilder, err := NewArchiveBuilder(agentBundlePath, logger)
 	if err != nil {
 		return fmt.Errorf("unable to create agent bundle archive builder: %w", err)
 	}
 	for _, target := range agentTargets {
 		agentBuildPath := filepath.Join(agentBuildSubdirectoryPath, target.Name())
 		if err := agentBundleBuilder.Add(target.Name(), agentBuildPath, 0755); err != nil {
-			agentBundleBuilder.Close()
+			must.Close(agentBundleBuilder, logger)
 			return fmt.Errorf("unable to add agent to bundle: %w", err)
 		}
 	}
@@ -703,13 +709,13 @@ func build() error {
 			)
 
 			// Build the release bundle.
-			if releaseBundle, err := NewArchiveBuilder(releaseBundlePath); err != nil {
+			if releaseBundle, err := NewArchiveBuilder(releaseBundlePath, logger); err != nil {
 				return fmt.Errorf("unable to create release bundle: %w", err)
 			} else if err = releaseBundle.Add(target.ExecutableName(cliBaseName), cliBuildPath, 0755); err != nil {
-				releaseBundle.Close()
+				must.Close(releaseBundle, logger)
 				return fmt.Errorf("unable to add CLI to release bundle: %w", err)
 			} else if err = releaseBundle.Add("", agentBundlePath, 0644); err != nil {
-				releaseBundle.Close()
+				must.Close(releaseBundle, logger)
 				return fmt.Errorf("unable to add agent bundle to release bundle: %w", err)
 			} else if err = releaseBundle.Close(); err != nil {
 				return fmt.Errorf("unable to finalize release bundle: %w", err)
@@ -721,7 +727,7 @@ func build() error {
 	log.Println("Copying binary for testing")
 	localCLIBuildPath := filepath.Join(cliBuildSubdirectoryPath, localTarget.Name())
 	localCLIRelocationPath := filepath.Join(buildPath, localTarget.ExecutableName(cliBaseName))
-	if err := copyFile(localCLIBuildPath, localCLIRelocationPath); err != nil {
+	if err := copyFile(localCLIBuildPath, localCLIRelocationPath, logger); err != nil {
 		return fmt.Errorf("unable to copy current platform CLI: %w", err)
 	}
 

--- a/tools/scan_bench/main.go
+++ b/tools/scan_bench/main.go
@@ -19,6 +19,8 @@ import (
 	"github.com/mutagen-io/mutagen/cmd/profile"
 
 	"github.com/mutagen-io/mutagen/pkg/filesystem/behavior"
+	"github.com/mutagen-io/mutagen/pkg/logging"
+	"github.com/mutagen-io/mutagen/pkg/must"
 	"github.com/mutagen-io/mutagen/pkg/synchronization/core"
 	"github.com/mutagen-io/mutagen/pkg/synchronization/core/ignore"
 	dockerignore "github.com/mutagen-io/mutagen/pkg/synchronization/core/ignore/docker"
@@ -59,6 +61,7 @@ func ignoreCachesIntersectionEqual(first, second ignore.IgnoreCache) bool {
 }
 
 func main() {
+	logger := logging.NewLogger(logging.LevelError, os.Stderr)
 	// Parse command line arguments.
 	flagSet := pflag.NewFlagSet("scan_bench", pflag.ContinueOnError)
 	flagSet.SetOutput(io.Discard)
@@ -72,7 +75,7 @@ func main() {
 	flagSet.StringSliceVarP(&ignores, "ignore", "i", nil, "specify ignore paths")
 	if err := flagSet.Parse(os.Args[1:]); err != nil {
 		if err == pflag.ErrHelp {
-			fmt.Fprint(os.Stdout, usage)
+			must.Fprint(os.Stdout, logger, usage)
 			return
 		} else {
 			cmd.Fatal(fmt.Errorf("unable to parse command line: %w", err))
@@ -157,6 +160,7 @@ func main() {
 		behavior.ProbeMode_ProbeModeProbe,
 		core.SymbolicLinkMode_SymbolicLinkModePortable,
 		core.PermissionsMode_PermissionsModePortable,
+		logger,
 	)
 	if err != nil {
 		cmd.Fatal(fmt.Errorf("unable to perform cold scan: %w", err))
@@ -192,6 +196,7 @@ func main() {
 		behavior.ProbeMode_ProbeModeProbe,
 		core.SymbolicLinkMode_SymbolicLinkModePortable,
 		core.PermissionsMode_PermissionsModePortable,
+		logger,
 	)
 	if err != nil {
 		cmd.Fatal(fmt.Errorf("unable to perform warm scan: %w", err))
@@ -235,6 +240,7 @@ func main() {
 		behavior.ProbeMode_ProbeModeProbe,
 		core.SymbolicLinkMode_SymbolicLinkModePortable,
 		core.PermissionsMode_PermissionsModePortable,
+		logger,
 	)
 	if err != nil {
 		cmd.Fatal(fmt.Errorf("unable to perform second warm scan: %w", err))
@@ -276,6 +282,7 @@ func main() {
 		behavior.ProbeMode_ProbeModeProbe,
 		core.SymbolicLinkMode_SymbolicLinkModePortable,
 		core.PermissionsMode_PermissionsModePortable,
+		logger,
 	)
 	if err != nil {
 		cmd.Fatal(fmt.Errorf("unable to perform accelerated scan (with re-check paths): %w", err))
@@ -315,6 +322,7 @@ func main() {
 		behavior.ProbeMode_ProbeModeProbe,
 		core.SymbolicLinkMode_SymbolicLinkModePortable,
 		core.PermissionsMode_PermissionsModePortable,
+		logger,
 	)
 	if err != nil {
 		cmd.Fatal(fmt.Errorf("unable to perform accelerated scan (without re-check paths): %w", err))

--- a/tools/watch_demo/watch_demo.go
+++ b/tools/watch_demo/watch_demo.go
@@ -9,9 +9,13 @@ import (
 	"github.com/mutagen-io/mutagen/cmd"
 
 	"github.com/mutagen-io/mutagen/pkg/filesystem/watching"
+	"github.com/mutagen-io/mutagen/pkg/logging"
+	"github.com/mutagen-io/mutagen/pkg/must"
 )
 
 func main() {
+	logger := logging.NewLogger(logging.LevelError, os.Stderr)
+
 	// Parse arguments.
 	if len(os.Args) != 2 {
 		cmd.Fatal(errors.New("invalid number of arguments"))
@@ -57,7 +61,7 @@ func main() {
 			cmd.Fatal(fmt.Errorf("watching failed: %w", err))
 		case <-signalTermination:
 			fmt.Println("Received termination signal, terminating watching...")
-			watcher.Terminate()
+			must.Terminate(watcher, logger)
 		}
 	}
 }


### PR DESCRIPTION

## NOTE: This is a LARGE PR but it only does one thing. If you may want to accept it, you should do before you add a lot of new code or it will just be too hard to resolve the conflicts.  HOWEVER, this PR chances the API so to follow SemVer you would need to bump the major version number I think.

<hr>

## Purpose 

This PR replaces finds almost all places where an error is returned by a function — but the Mutagen code just ignores the error — and it adds logging in case an error is returned.

I discovered these issues while I was making changes for my own needs on my fork for #505. My IDE kept complaining about unhandled errors, so I decided to fix them and move to a separate PR.  As it turned out, fixing them was quite the rabbit hole, but I did so because I know having all unhandled errors logged will make for more robust software and potentially reveal edge-case bugs in the code you did not even realize where there. 

Serendipitously DoltHub published a blog post entitled _"[_What's the best Static Analysis tool for Golang_](https://www.dolthub.com/blog/2024-07-24-static-analysis/)?"_ that starts with an example of an unhandled error as justification for why handling all errors is so important. I say _"serendipitously"_ because it was published _after_ I wrote the code for this PR.

## What the PR Changed
1. The PR adds a package named `must` which includes functions for most of the places where errors were being ignored, such as `Close()`, `Shudown()`, etc.  Then is replaces the code that looks like this:

    ```
    item.Close()
    ``` 
    With code that looks like this:    
    ```
    must.Close(item,logger)
    ```
    
2. In order to ensure a `logger` was always available, this PR adds:
    a. A `logger` property to every struct that has a method where unhandled errors occurred, or
    b. A `logger` parameter for every package function where unhandled errors occurred, and 
    c. Ensured those properties were set and parameters were passed in all cases.
    
3. In the very few cases that use interfaces I decided to handle the error manually so as not to modify the interface.

4. In one case I could not find a reasonable way to get a `logger` so I just left a `TODO` comment.

## Summary
I really hope you will consider accepting this. It was a few days of work to both find and fix all the case and to them get all the CI tests to pass.  If you do, I think it will help you make `Mutagen` even more robust moving forward.

    