### PR TITLE
ci: make Windows partition setup to mirrors with different names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,18 @@ jobs:
         shell: bash
       - run: scripts/ci/setup_docker.sh
         shell: bash
-      - run: diskpart /s scripts\ci\setup_partitions_windows.txt
+      - name: "Prepare Windows partition script"
+        run: |
+          # Populate the partition setup script with the repository path since
+          # diskpart doesn't support relative paths or environment variable
+          # substitution. While we could hardcode a path into the script, that
+          # breaks CI for mirrors that have a different repository name.
+          REPONAME="$(basename "$(pwd)")"
+          sed -e "s/REPONAME/D:\\\\a\\\\${REPONAME}\\\\${REPONAME}/g" \
+            scripts/ci/setup_partitions_windows_template.txt \
+            > setup_partitions_windows.txt
+        shell: bash
+      - run: diskpart /s setup_partitions_windows.txt
       - run: scripts/ci/analyze.sh
         shell: bash
       - run: scripts/ci/test.sh

--- a/scripts/ci/setup_partitions_windows_template.txt
+++ b/scripts/ci/setup_partitions_windows_template.txt
@@ -1,4 +1,4 @@
-create vdisk file=D:\a\mutagen\mutagen\fat32image.vhdx maximum=50 type=fixed
+create vdisk file=REPONAME\fat32image.vhdx maximum=50 type=fixed
 attach vdisk
 create partition primary
 format quick fs=fat32 label=FAT32ROOT


### PR DESCRIPTION
<!--

Thanks for the pull request! Before submitting, please ensure that your commits
adhere to the guidelines in CONTRIBUTING.md. Pull requests that do not meet
these guidelines cannot be merged.

If you're not quite ready for a final review, please feel free to open a draft
pull request.

Thanks for taking the time to open a pull request!

-->

**What does this pull request do and why is it needed?**

This PR fixes Windows CI partitioning to work in mirrors of the repo with different names.
