### PR TITLE
ci: only attempt to push sidecar image from canonical repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
-        if: github.ref_type == 'tag'
+        if: github.ref_type == 'tag' && github.action_repository == 'mutagen-io/mutagen'
         with:
           username: ${{ secrets.SIDECAR_DEPLOYMENT_USER }}
           password: ${{ secrets.SIDECAR_DEPLOYMENT_TOKEN }}
@@ -143,7 +143,7 @@ jobs:
           file: images/sidecar/linux/Dockerfile
           target: mit
           tags: ${{ steps.tag.outputs.tag }}
-          push: ${{ github.ref_type == 'tag' }}
+          push: ${{ github.ref_type == 'tag' && github.action_repository == 'mutagen-io/mutagen' }}
           platforms: |
             linux/386
             linux/amd64
@@ -156,7 +156,7 @@ jobs:
           file: images/sidecar/linux/Dockerfile
           target: sspl
           tags: ${{ steps.tag.outputs.tag }}-sspl
-          push: ${{ github.ref_type == 'tag' }}
+          push: ${{ github.ref_type == 'tag' && github.action_repository == 'mutagen-io/mutagen' }}
           platforms: |
             linux/386
             linux/amd64


### PR DESCRIPTION
<!--

Thanks for the pull request! Before submitting, please ensure that your commits
adhere to the guidelines in CONTRIBUTING.md. Pull requests that do not meet
these guidelines cannot be merged.

If you're not quite ready for a final review, please feel free to open a draft
pull request.

Thanks for taking the time to open a pull request!

-->

**What does this pull request do and why is it needed?**

This PR modifies the CI setup so that only the canonical repository attempts to push a sidecar image. This is to stop forks (which don't have the necessary secrets) from erroring out in the relevant actions.
