### PR TITLE
docker: handle new error code delineation in Moby v28+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23.2'
+          go-version: '1.23.6'
       - name: "Install sha256sum"
         run: brew install coreutils
       - run: scripts/ci/setup_go.sh
@@ -72,7 +72,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        goversion: ['1.22.8', '1.23.2']
+        goversion: ['1.22.12', '1.23.6']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23.2'
+          go-version: '1.23.6'
       - run: scripts/ci/setup_go.sh
         shell: bash
       - run: scripts/ci/setup_docker.sh
@@ -127,7 +127,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23.2'
+          go-version: '1.23.6'
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3

--- a/images/sidecar/linux/Dockerfile
+++ b/images/sidecar/linux/Dockerfile
@@ -1,5 +1,5 @@
 # Use an Alpine-based Go builder.
-FROM golang:1.23.6-alpine3.20 AS builder
+FROM golang:1.23.6-alpine3.21 AS builder
 
 # Disable cgo in order to match the behavior of our release binaries (and to
 # avoid the need for gcc on certain architectures).
@@ -21,7 +21,7 @@ RUN ["go", "build", "-o", "mutagen-agent-sspl", "-tags", "mutagenagent,mutagenss
 
 
 # Switch to a vanilla Alpine base for the final image.
-FROM alpine:3.20 AS base
+FROM alpine:3.21 AS base
 
 # Copy the sidecar entry point from the builder.
 COPY --from=builder ["/mutagen/mutagen-sidecar", "/usr/bin/mutagen-sidecar"]

--- a/images/sidecar/linux/Dockerfile
+++ b/images/sidecar/linux/Dockerfile
@@ -1,5 +1,5 @@
 # Use an Alpine-based Go builder.
-FROM golang:1.23.2-alpine3.20 AS builder
+FROM golang:1.23.6-alpine3.20 AS builder
 
 # Disable cgo in order to match the behavior of our release binaries (and to
 # avoid the need for gcc on certain architectures).

--- a/scripts/ci/docker/linux/Dockerfile
+++ b/scripts/ci/docker/linux/Dockerfile
@@ -1,5 +1,5 @@
 # Set the base image.
-FROM alpine:3.20
+FROM alpine:3.21
 
 # Add the HTTP demo server.
 COPY ["httpdemo", "/httpdemo"]


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This PR fixes an issue with error code detection for Moby v28, which now delineates "command not found" into the proper 127 exit code.

**Which issue(s) does this pull request address (if any)?**

https://github.com/ddev/ddev/issues/7015

**Any other notes for the review process?**

This PR also updates Go and Alpine dependencies.

A backport will be required for a v0.18.1 release.

CC @rfay 
