### PR TITLE
Adding option to specify agent bundle location via env var

### DIFF
--- a/pkg/agent/bundle.go
+++ b/pkg/agent/bundle.go
@@ -19,6 +19,8 @@ import (
 const (
 	// BundleName is the base name of the agent bundle.
 	BundleName = "mutagen-agents.tar.gz"
+	// BundleLocationEnvVarName defines the env var storing the bundle location
+	BundleLocationEnvVarName = "MUTAGEN_BUNDLE_LOCATION"
 )
 
 // BundleLocation encodes an expected location for the agent bundle.
@@ -55,6 +57,15 @@ func ExecutableForPlatform(goos, goarch, outputPath string) (string, error) {
 	// Compute the path to the location in which we expect to find the agent
 	// bundle.
 	var bundleSearchPaths []string
+
+	envBundleLocation := os.Getenv(BundleLocationEnvVarName)
+	if envBundleLocation != "" {
+		// Add a bundle path is defined via env, and exists, add it to the search paths
+		if _, err := os.Stat(envBundleLocation); err == nil {
+			bundleSearchPaths = append(bundleSearchPaths, envBundleLocation)
+		}
+	}
+
 	if ExpectedBundleLocation == BundleLocationDefault {
 		// Add the executable directory as a search path.
 		if executablePath, err := os.Executable(); err != nil {


### PR DESCRIPTION
**What does this pull request do and why is it needed?**
This change allows the mutagen agent bundle code to add agent search locations via an additional env var. If the agent tar is in a different directory than the binary then this can be used to point to the location of the tar.gz file

This does include populating search paths form env in all cases, however it should be a lightweight change, and will only take action if there is a value set. If there is an issue verifying that the folder exists, the following behaviour will not be changed. Worst case, if a value is specified unintentionally, then the modified behaviour will mean we look in one additional folder when trying to find the agents file.
