### PR TITLE
sync: create missing parent hierarchy for remote beta roots

### DIFF
--- a/pkg/synchronization/endpoint/remote/server.go
+++ b/pkg/synchronization/endpoint/remote/server.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 
 	"google.golang.org/protobuf/proto"
 
@@ -31,6 +33,31 @@ type endpointServer struct {
 	encoder *encoding.ProtobufEncoder
 	// decoder is the control stream decoder.
 	decoder *encoding.ProtobufDecoder
+}
+
+// ensureSynchronizationRootParentExists ensures that the parent directory chain
+// for a synchronization root exists if the root itself doesn't already exist.
+func ensureSynchronizationRootParentExists(root string) error {
+	// If the synchronization root already exists, then there's nothing to do.
+	if _, err := os.Lstat(root); err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("unable to query synchronization root: %w", err)
+	}
+
+	// Compute the parent directory. If the root is a filesystem root, then
+	// there's no higher-level directory hierarchy to create.
+	parent := filepath.Dir(root)
+	if parent == root {
+		return nil
+	}
+
+	// Create any missing parent directories using standard mkdir -p semantics.
+	if err := os.MkdirAll(parent, 0777); err != nil {
+		return fmt.Errorf("unable to create synchronization root parent directory hierarchy: %w", err)
+	}
+
+	return nil
 }
 
 // ServeEndpoint creates and serves a endpoint server on the specified stream.
@@ -102,6 +129,18 @@ func ServeEndpoint(logger *logging.Logger, stream io.ReadWriteCloser) error {
 		return err
 	} else {
 		request.Root = r
+	}
+
+	// For remote beta endpoints, ensure that the synchronization root's parent
+	// directory chain exists so that a missing directory root can be created by
+	// the normal transition logic.
+	if !request.Alpha {
+		if err := ensureSynchronizationRootParentExists(request.Root); err != nil {
+			err = fmt.Errorf("unable to prepare synchronization root parent directory hierarchy: %w", err)
+			encoder.Encode(&InitializeSynchronizationResponse{Error: err.Error()})
+			flusher.Flush()
+			return err
+		}
 	}
 
 	// Create the underlying endpoint. If it fails to create, then send a

--- a/pkg/synchronization/endpoint/remote/server_test.go
+++ b/pkg/synchronization/endpoint/remote/server_test.go
@@ -1,3 +1,34 @@
 package remote
 
-// TODO: Implement.
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEnsureSynchronizationRootParentExistsCreatesMissingParentsOnly(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "missing", "parent", "root")
+
+	if err := ensureSynchronizationRootParentExists(root); err != nil {
+		t.Fatalf("unable to ensure parent hierarchy: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Dir(root)); err != nil {
+		t.Fatalf("parent directory hierarchy not created: %v", err)
+	}
+
+	if _, err := os.Stat(root); !os.IsNotExist(err) {
+		t.Fatalf("synchronization root should not be created directly, err: %v", err)
+	}
+}
+
+func TestEnsureSynchronizationRootParentExistsNoopIfRootExists(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "root")
+	if err := os.Mkdir(root, 0700); err != nil {
+		t.Fatalf("unable to create test root: %v", err)
+	}
+
+	if err := ensureSynchronizationRootParentExists(root); err != nil {
+		t.Fatalf("unable to ensure parent hierarchy for existing root: %v", err)
+	}
+}


### PR DESCRIPTION
What does this pull request do and why is it needed?

This pull request allows writable remote beta endpoints to create the missing
parent directory hierarchy for a synchronization root when the root itself does
not yet exist.

Today, synchronization can proceed if the root is missing but its parent
directory already exists. However, if the parent hierarchy is missing,
transition fails when attempting to walk to the synchronization root parent.

This change keeps the behavior narrow:

- it only applies to remote beta endpoints
- it only runs when the synchronization root itself does not exist
- it only creates the missing parent directory hierarchy
- it does not eagerly create the root leaf itself
- existing behavior is preserved when the root already exists
- clear errors are preserved if parent directory creation fails

This is needed to make first-time remote synchronization setup work more
smoothly when the target directory hierarchy has not yet been created on the
remote side.

Which issue(s) does this pull request address (if any)?

Closes #553 

Any other notes for the review process?

This PR also adds tests covering:

- creation of missing parent directories without eagerly creating the root
- no-op behavior when the root already exists
