### PR TITLE
Replace archived groupcache dependency with generic LRU cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/eknkc/basex v1.0.1
 	github.com/fatih/color v1.19.0
-	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/google/uuid v1.6.0
 	github.com/hectane/go-acl v0.0.0-20230122075934-ca0b05cb1adb
 	github.com/klauspost/compress v1.18.5

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,6 @@ github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
-github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
-github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/pkg/container/lru/lru.go
+++ b/pkg/container/lru/lru.go
@@ -1,0 +1,107 @@
+// Package lru provides a generic LRU (least recently used) cache.
+package lru
+
+import "container/list"
+
+// Cache is a generic LRU cache. It is not safe for concurrent
+// access. The zero value is not usable; create instances with New.
+type Cache[K comparable, V any] struct {
+	// maxEntries is the maximum number of entries before eviction.
+	// A value of zero means no limit.
+	maxEntries int
+	// onEvicted is an optional callback invoked when an entry is
+	// evicted from the cache (either due to capacity overflow or
+	// explicit removal).
+	onEvicted func(key K, value V)
+	// entries is the doubly-linked list that maintains recency
+	// order. The front of the list is the most recently used.
+	entries *list.List
+	// index maps keys to their corresponding list elements for
+	// O(1) lookup.
+	index map[K]*list.Element
+}
+
+// entry is a key-value pair stored in the linked list.
+type entry[K comparable, V any] struct {
+	// key is the cache key.
+	key K
+	// value is the cached value.
+	value V
+}
+
+// New creates a new LRU cache with the specified maximum number of
+// entries. If maxEntries is zero, the cache has no limit and the
+// caller is responsible for managing eviction. The onEvicted
+// callback, if non-nil, is called when an entry is evicted.
+func New[K comparable, V any](
+	maxEntries int,
+	onEvicted func(key K, value V),
+) *Cache[K, V] {
+	return &Cache[K, V]{
+		maxEntries: maxEntries,
+		onEvicted:  onEvicted,
+		entries:    list.New(),
+		index:      make(map[K]*list.Element),
+	}
+}
+
+// Add inserts or updates an entry in the cache. If the key already
+// exists, its value is updated and the entry is moved to the front
+// (most recently used). If the cache is at capacity, the least
+// recently used entry is evicted.
+func (c *Cache[K, V]) Add(key K, value V) {
+	if e, ok := c.index[key]; ok {
+		c.entries.MoveToFront(e)
+		e.Value.(*entry[K, V]).value = value
+		return
+	}
+	e := c.entries.PushFront(&entry[K, V]{key, value})
+	c.index[key] = e
+	if c.maxEntries != 0 && c.entries.Len() > c.maxEntries {
+		c.removeOldest()
+	}
+}
+
+// Get retrieves an entry from the cache. If the key is found, the
+// entry is moved to the front (most recently used) and the value
+// and true are returned. If not found, the zero value and false
+// are returned.
+func (c *Cache[K, V]) Get(key K) (value V, ok bool) {
+	if e, hit := c.index[key]; hit {
+		c.entries.MoveToFront(e)
+		return e.Value.(*entry[K, V]).value, true
+	}
+	return
+}
+
+// Remove removes the entry with the specified key from the cache.
+// If an eviction callback is set, it is called with the removed
+// entry. This is a no-op if the key is not present.
+func (c *Cache[K, V]) Remove(key K) {
+	if e, hit := c.index[key]; hit {
+		c.removeElement(e)
+	}
+}
+
+// Len returns the number of entries in the cache.
+func (c *Cache[K, V]) Len() int {
+	return c.entries.Len()
+}
+
+// removeOldest removes the least recently used entry.
+func (c *Cache[K, V]) removeOldest() {
+	if e := c.entries.Back(); e != nil {
+		c.removeElement(e)
+	}
+}
+
+// removeElement removes an element from the cache and invokes the
+// eviction callback if set.
+func (c *Cache[K, V]) removeElement(e *list.Element) {
+	c.entries.Remove(e)
+	kv := e.Value.(*entry[K, V])
+	delete(c.index, kv.key)
+	if c.onEvicted != nil {
+		c.onEvicted(kv.key, kv.value)
+	}
+}

--- a/pkg/container/lru/lru_test.go
+++ b/pkg/container/lru/lru_test.go
@@ -1,0 +1,165 @@
+package lru
+
+import "testing"
+
+// TestBasicAddAndGet tests basic cache insertion and retrieval.
+func TestBasicAddAndGet(t *testing.T) {
+	cache := New[string, int](2, nil)
+	cache.Add("a", 1)
+	cache.Add("b", 2)
+
+	if v, ok := cache.Get("a"); !ok || v != 1 {
+		t.Fatalf("expected (1, true), got (%d, %t)", v, ok)
+	}
+	if v, ok := cache.Get("b"); !ok || v != 2 {
+		t.Fatalf("expected (2, true), got (%d, %t)", v, ok)
+	}
+	if _, ok := cache.Get("c"); ok {
+		t.Fatal("expected miss for key 'c'")
+	}
+}
+
+// TestEviction tests that the least recently used entry is evicted
+// when the cache exceeds its capacity.
+func TestEviction(t *testing.T) {
+	cache := New[string, int](2, nil)
+	cache.Add("a", 1)
+	cache.Add("b", 2)
+	cache.Add("c", 3)
+
+	if _, ok := cache.Get("a"); ok {
+		t.Fatal("expected 'a' to be evicted")
+	}
+	if v, ok := cache.Get("b"); !ok || v != 2 {
+		t.Fatalf("expected (2, true), got (%d, %t)", v, ok)
+	}
+	if v, ok := cache.Get("c"); !ok || v != 3 {
+		t.Fatalf("expected (3, true), got (%d, %t)", v, ok)
+	}
+}
+
+// TestEvictionCallback tests that the eviction callback is called
+// with the correct key and value when an entry is evicted.
+func TestEvictionCallback(t *testing.T) {
+	var evictedKey string
+	var evictedValue int
+	onEvicted := func(k string, v int) {
+		evictedKey = k
+		evictedValue = v
+	}
+
+	cache := New[string, int](2, onEvicted)
+	cache.Add("a", 1)
+	cache.Add("b", 2)
+	cache.Add("c", 3)
+
+	if evictedKey != "a" || evictedValue != 1 {
+		t.Fatalf(
+			"expected eviction of (a, 1), got (%s, %d)",
+			evictedKey, evictedValue,
+		)
+	}
+}
+
+// TestRecencyPromotion tests that accessing an entry promotes it
+// to the front of the cache, preventing its eviction.
+func TestRecencyPromotion(t *testing.T) {
+	cache := New[string, int](2, nil)
+	cache.Add("a", 1)
+	cache.Add("b", 2)
+
+	// Access "a" to promote it.
+	cache.Get("a")
+
+	// Adding "c" should evict "b" (the least recently used), not
+	// "a" (which was just accessed).
+	cache.Add("c", 3)
+
+	if _, ok := cache.Get("a"); !ok {
+		t.Fatal("expected 'a' to survive (was promoted)")
+	}
+	if _, ok := cache.Get("b"); ok {
+		t.Fatal("expected 'b' to be evicted")
+	}
+}
+
+// TestUpdateExisting tests that adding an entry with an existing
+// key updates the value and promotes the entry.
+func TestUpdateExisting(t *testing.T) {
+	cache := New[string, int](2, nil)
+	cache.Add("a", 1)
+	cache.Add("b", 2)
+
+	// Update "a" to a new value.
+	cache.Add("a", 10)
+
+	if v, ok := cache.Get("a"); !ok || v != 10 {
+		t.Fatalf("expected (10, true), got (%d, %t)", v, ok)
+	}
+
+	// "a" was promoted by the update, so "b" should be evicted
+	// when a third entry is added.
+	cache.Add("c", 3)
+	if _, ok := cache.Get("b"); ok {
+		t.Fatal("expected 'b' to be evicted")
+	}
+}
+
+// TestExplicitRemove tests that explicitly removed entries trigger
+// the eviction callback.
+func TestExplicitRemove(t *testing.T) {
+	var evictedKey string
+	onEvicted := func(k string, v int) {
+		evictedKey = k
+	}
+
+	cache := New[string, int](10, onEvicted)
+	cache.Add("a", 1)
+	cache.Remove("a")
+
+	if evictedKey != "a" {
+		t.Fatalf("expected eviction of 'a', got '%s'", evictedKey)
+	}
+	if _, ok := cache.Get("a"); ok {
+		t.Fatal("expected miss after removal")
+	}
+	if cache.Len() != 0 {
+		t.Fatalf("expected length 0, got %d", cache.Len())
+	}
+}
+
+// TestRemoveNonExistent tests that removing a non-existent key is
+// a no-op.
+func TestRemoveNonExistent(t *testing.T) {
+	cache := New[string, int](10, nil)
+	cache.Remove("nonexistent")
+}
+
+// TestLen tests the Len method.
+func TestLen(t *testing.T) {
+	cache := New[string, int](10, nil)
+	if cache.Len() != 0 {
+		t.Fatalf("expected length 0, got %d", cache.Len())
+	}
+	cache.Add("a", 1)
+	cache.Add("b", 2)
+	if cache.Len() != 2 {
+		t.Fatalf("expected length 2, got %d", cache.Len())
+	}
+	cache.Remove("a")
+	if cache.Len() != 1 {
+		t.Fatalf("expected length 1, got %d", cache.Len())
+	}
+}
+
+// TestZeroMaxEntries tests that a cache with zero maxEntries has
+// no eviction limit.
+func TestZeroMaxEntries(t *testing.T) {
+	cache := New[string, int](0, nil)
+	for i := range 1000 {
+		cache.Add(string(rune('a'+i)), i)
+	}
+	if cache.Len() != 1000 {
+		t.Fatalf("expected length 1000, got %d", cache.Len())
+	}
+}

--- a/pkg/filesystem/watching/watch_non_recursive_linux.go
+++ b/pkg/filesystem/watching/watch_non_recursive_linux.go
@@ -7,8 +7,7 @@ import (
 	"os"
 	"sync"
 
-	"github.com/golang/groupcache/lru"
-
+	"github.com/mutagen-io/mutagen/pkg/container/lru"
 	"github.com/mutagen-io/mutagen/pkg/filesystem/watching/internal/third_party/notify"
 )
 
@@ -31,7 +30,7 @@ type nonRecursiveWatcher struct {
 	// watch is the underlying inotify-based watcher.
 	watch notify.Watcher
 	// evictor performs LRU-based watch eviction.
-	evictor *lru.Cache
+	evictor *lru.Cache[string, int]
 	// events is the event delivery channel.
 	events chan string
 	// errors is the error delivery channel.
@@ -50,28 +49,26 @@ func NewNonRecursiveWatcher() (NonRecursiveWatcher, error) {
 	// Create a context to regulate the watcher's run loop.
 	ctx, cancel := context.WithCancel(context.Background())
 
-	// Create the watcher.
+	// Create the watcher. The LRU evictor ensures that we don't
+	// exceed the maximum number of inotify watches by unwatching the
+	// least recently used paths when the cache overflows.
 	watcher := &nonRecursiveWatcher{
-		watch:   notify.NewWatcher(rawEvents),
-		evictor: lru.New(inotifyDefaultMaximumWatches),
-		events:  make(chan string),
-		errors:  make(chan error, 1),
-		cancel:  cancel,
+		watch:  notify.NewWatcher(rawEvents),
+		events: make(chan string),
+		errors: make(chan error, 1),
+		cancel: cancel,
 	}
-
-	// Set the eviction handler.
-	watcher.evictor.OnEvicted = func(key lru.Key, _ any) {
-		if path, ok := key.(string); !ok {
-			panic("invalid key type in watch path cache")
-		} else {
+	watcher.evictor = lru.New[string, int](
+		inotifyDefaultMaximumWatches,
+		func(path string, _ int) {
 			if err := watcher.watch.Unwatch(path); err != nil {
 				select {
 				case watcher.errors <- fmt.Errorf("unwatch error: %w", err):
 				default:
 				}
 			}
-		}
-	}
+		},
+	)
 
 	// Track run loop termination.
 	watcher.done.Add(1)

--- a/pkg/mutagen/licenses.go
+++ b/pkg/mutagen/licenses.go
@@ -53,18 +53,6 @@ notice is preserved.
 
 --------------------------------------------------------------------------------
 
-groupcache
-
-https://github.com/golang/groupcache
-
-Copyright 2013 Google Inc.
-
-Used under the terms of the Apache License, Version 2.0. A copy of this license
-can be found later in this text or online at
-http://www.apache.org/licenses/LICENSE-2.0.
-
---------------------------------------------------------------------------------
-
 Cobra
 
 https://github.com/spf13/cobra


### PR DESCRIPTION
## Summary

Replace `github.com/golang/groupcache` (archived by Google) with a
new generic LRU cache implementation at `pkg/container/lru`.

- The only usage was in `pkg/filesystem/watching` for inotify watch
  eviction on Linux.
- The new implementation uses Go generics for type safety, eliminating
  the runtime type assertions the old `interface{}`-based API required.
- All operations are O(1) (map + doubly-linked list).
- Full test coverage (9 tests covering basic ops, eviction, recency
  promotion, callbacks, edge cases).
- Removed groupcache license entry from `pkg/mutagen/licenses.go`.

## Test plan

- [x] `go test ./pkg/container/lru/` passes (9/9)
- [x] `go build ./cmd/... ./pkg/...` passes
- [x] `go vet ./cmd/... ./pkg/...` passes clean
- [x] `GOOS=linux go build ./pkg/filesystem/watching/...` passes
- [x] CI passes on all platforms