### PR TITLE
Migrate from yaml.v2 to go.yaml.in/yaml/v4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,31 @@ follow the code and update this file.
 - The `k8s.io/apimachinery` replace directive in `go.mod` is
   intentional.
 
+## Dependency License Compliance
+
+When adding or updating dependencies, verify FOSS license
+compliance before committing:
+
+- Check the dependency's license and notice files at the target
+  version. These may appear as `LICENSE`, `NOTICE`, `COPYING`,
+  `PATENTS`, or variants with extensions like `.md`, `.txt`,
+  or `.rst`.
+- **Search for embedded third-party code.** Some dependencies
+  copy source files from other projects (not tracked as Go
+  module dependencies). Scan for files with different copyright
+  headers: `grep -ri "Copyright" --include="*.go"` across the
+  dependency's source tree. NOTICE files often list these. See
+  `github.com/klauspost/compress` as an example.
+- For dependency updates, diff the tag delta and look for new
+  files with new copyright headers, added or changed license
+  files, and new subdirectories containing ported code.
+- Update license notice files to reflect any changes to copyright
+  holders, license terms, or embedded code attribution.
+  Dependencies shared by both SSPL and non-SSPL builds go in
+  `pkg/mutagen/licenses.go`. Dependencies used only in SSPL
+  builds go in `licenses_sspl.go`, and those used only in
+  non-SSPL builds go in `licenses_nosspl.go`.
+
 ## Change Guidance
 
 - Follow `CONTRIBUTING.md` for code style.

--- a/go.mod
+++ b/go.mod
@@ -18,13 +18,13 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/zeebo/xxh3 v1.1.0
+	go.yaml.in/yaml/v4 v4.0.0-rc.4
 	golang.org/x/net v0.53.0
 	golang.org/x/sys v0.43.0
 	golang.org/x/text v0.36.0
 	google.golang.org/grpc v1.80.0
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.6.1
 	google.golang.org/protobuf v1.36.11
-	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/apimachinery v0.21.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -93,7 +93,6 @@ github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -117,7 +116,6 @@ github.com/mutagen-io/fsevents v0.0.0-20230629001834-f53e17b91ebc/go.mod h1:kmTy
 github.com/mutagen-io/gopass v0.0.0-20230214181532-d4b7cdfe054c h1:c0xgZ8mF6PwiDc6aW2MEcdaCXxkt5K30kzylWqkT4oc=
 github.com/mutagen-io/gopass v0.0.0-20230214181532-d4b7cdfe054c/go.mod h1:Q87jWQAqEC/UdnYLd+A0mfR9oZl5gk6g/xvxzTpwLv8=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
-github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -158,6 +156,8 @@ go.opentelemetry.io/otel/sdk/metric v1.39.0/go.mod h1:xq9HEVH7qeX69/JnwEfp6fVq5w
 go.opentelemetry.io/otel/trace v1.39.0 h1:2d2vfpEDmCJ5zVYz7ijaJdOF59xLomrvj7bjt6/qCJI=
 go.opentelemetry.io/otel/trace v1.39.0/go.mod h1:88w4/PnZSazkGzz/w84VHpQafiU4EtqqlVdxWy+rNOA=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+go.yaml.in/yaml/v4 v4.0.0-rc.4 h1:UP4+v6fFrBIb1l934bDl//mmnoIZEDK0idg1+AIvX5U=
+go.yaml.in/yaml/v4 v4.0.0-rc.4/go.mod h1:aZqd9kCMsGL7AuUv/m/PvWLdg5sjJsZ4oHDEnfPPfY0=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -253,7 +253,6 @@ google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
@@ -261,7 +260,6 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWD
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/pkg/encoding/yaml.go
+++ b/pkg/encoding/yaml.go
@@ -1,13 +1,18 @@
 package encoding
 
 import (
-	"gopkg.in/yaml.v2"
+	"bytes"
+
+	"go.yaml.in/yaml/v4"
 )
 
-// LoadAndUnmarshalYAML loads data from the specified path and decodes it into
-// the specified structure.
+// LoadAndUnmarshalYAML loads data from the specified path and
+// decodes it into the specified structure. Unknown fields and
+// duplicate keys in the YAML are treated as errors.
 func LoadAndUnmarshalYAML(path string, value any) error {
 	return LoadAndUnmarshal(path, func(data []byte) error {
-		return yaml.UnmarshalStrict(data, value)
+		decoder := yaml.NewDecoder(bytes.NewReader(data))
+		decoder.KnownFields(true)
+		return decoder.Decode(value)
 	})
 }

--- a/pkg/mutagen/licenses.go
+++ b/pkg/mutagen/licenses.go
@@ -265,27 +265,19 @@ found online at https://opensource.org/licenses/BSD-3-Clause.
 
 yaml
 
-https://github.com/go-yaml/yaml
+https://github.com/yaml/go-yaml
 
-Copyright 2011-2016 Canonical Ltd.
+Copyright 2011-2019 Canonical Ltd
+Copyright 2025 The go-yaml Project Contributors
 
 Used under the terms of the Apache License, Version 2.0. A copy of this license
 can be found later in this text or online at
 http://www.apache.org/licenses/LICENSE-2.0.
 
-The following files were ported to Go from C files of libyaml, and thus
-are still covered by their original copyright and license:
+Portions of this library were ported to Go from C files of libyaml and are
+covered by the MIT License:
 
-    apic.go
-    emitterc.go
-    parserc.go
-    readerc.go
-    scannerc.go
-    writerc.go
-    yamlh.go
-    yamlprivateh.go
-
-Copyright (c) 2006 Kirill Simonov
+Copyright 2006-2010 Kirill Simonov
 
 Used under the terms of the MIT License. A copy of this license can be found
 later in this text or online at https://opensource.org/licenses/MIT.


### PR DESCRIPTION
## Summary

Replace `gopkg.in/yaml.v2` (unmaintained, archived April 2025)
with `go.yaml.in/yaml/v4`, the actively maintained successor
under the [YAML organization](https://github.com/yaml/go-yaml).

Thanks to @rfay for flagging the move away from the old package.

The only usage was in `pkg/encoding/yaml.go` via
`yaml.UnmarshalStrict`, which is replaced by the v4 Decoder API
with `KnownFields(true)` for equivalent strict unmarshaling
(rejects unknown fields and duplicate keys).

License entry updated to match yaml v4's LICENSE (pure Apache 2.0,
copyright transferred to The go-yaml Project Contributors).

Note: v4 is at `v4.0.0-rc.4`. The API is stable and Mutagen's
usage is minimal (one `Decode` call).

## Test plan

- [x] `go test ./pkg/encoding/ -run YAML` passes
- [x] `go build ./cmd/... ./pkg/...` passes
- [x] `go vet ./cmd/... ./pkg/...` passes clean
- [ ] CI passes on all platforms