### PR TITLE
Switch back to upstream fsevents

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,12 +8,12 @@ require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/eknkc/basex v1.0.1
 	github.com/fatih/color v1.19.0
+	github.com/fsnotify/fsevents v0.2.0
 	github.com/google/uuid v1.6.0
 	github.com/hectane/go-acl v0.0.0-20230122075934-ca0b05cb1adb
 	github.com/klauspost/compress v1.18.5
 	github.com/mattn/go-isatty v0.0.21
 	github.com/mutagen-io/extstat v0.0.0-20210224131814-32fa3f057fa8
-	github.com/mutagen-io/fsevents v0.0.0-20230629001834-f53e17b91ebc
 	github.com/mutagen-io/gopass v0.0.0-20230214181532-d4b7cdfe054c
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
 github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=
+github.com/fsnotify/fsevents v0.2.0 h1:BRlvlqjvNTfogHfeBOFvSC9N0Ddy+wzQCQukyoD7o/c=
+github.com/fsnotify/fsevents v0.2.0/go.mod h1:B3eEk39i4hz8y1zaWS/wPrAP4O6wkIl7HQwKBr1qH/w=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
@@ -111,8 +113,6 @@ github.com/mutagen-io/apimachinery v0.21.3-mutagen1 h1:7bnH35Ayna8ERRINDJ+J+bRd/
 github.com/mutagen-io/apimachinery v0.21.3-mutagen1/go.mod h1:H/IM+5vH9kZRNJ4l3x/fXP/5bOPJaVP/guptnZPeCFI=
 github.com/mutagen-io/extstat v0.0.0-20210224131814-32fa3f057fa8 h1:NEBqH/oVnWBunxdrdy1vlyGior8smhC6jZjxlWSG2BU=
 github.com/mutagen-io/extstat v0.0.0-20210224131814-32fa3f057fa8/go.mod h1:ZHGnLARFvfv0lUb6FsAS+LJHt9CFemt7K+mWfkw8nVA=
-github.com/mutagen-io/fsevents v0.0.0-20230629001834-f53e17b91ebc h1:yOGQ0Hc3NfOWYm9aaluKJEOZWEbpCPEm/TbPU87YumM=
-github.com/mutagen-io/fsevents v0.0.0-20230629001834-f53e17b91ebc/go.mod h1:kmTyqetTEgYl9KF5JlHLKL6LXnhs2/oK5100pcMZRn8=
 github.com/mutagen-io/gopass v0.0.0-20230214181532-d4b7cdfe054c h1:c0xgZ8mF6PwiDc6aW2MEcdaCXxkt5K30kzylWqkT4oc=
 github.com/mutagen-io/gopass v0.0.0-20230214181532-d4b7cdfe054c/go.mod h1:Q87jWQAqEC/UdnYLd+A0mfR9oZl5gk6g/xvxzTpwLv8=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=

--- a/pkg/filesystem/watching/watch_recursive_darwin_cgo.go
+++ b/pkg/filesystem/watching/watch_recursive_darwin_cgo.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/mutagen-io/fsevents"
+	"github.com/fsnotify/fsevents"
 )
 
 const (
@@ -111,7 +111,9 @@ func NewRecursiveWatcher(target string) (RecursiveWatcher, error) {
 		Latency: fseventsLatency,
 		Flags:   fseventsFlags,
 	}
-	watch.Start()
+	if err := watch.Start(); err != nil {
+		return nil, fmt.Errorf("unable to start FSEvents stream: %w", err)
+	}
 
 	// Create a context to regulate the watcher's run loop.
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/filesystem/watching/watch_test.go
+++ b/pkg/filesystem/watching/watch_test.go
@@ -94,6 +94,226 @@ func TestRecursiveWatcher(t *testing.T) {
 	verifyWatchEvent(t, watcher, map[string]bool{fileRelative: true})
 }
 
+// drainEvents consumes any buffered events from the watcher within a
+// short window. This is useful between test phases to avoid stale
+// events from one phase leaking into the next phase's verification.
+// FSEvents (and other watchers) may coalesce or delay events, so a
+// brief drain helps keep phases independent.
+func drainEvents(watcher RecursiveWatcher) {
+	timeout := time.NewTimer(200 * time.Millisecond)
+	defer timeout.Stop()
+	for {
+		select {
+		case <-watcher.Events():
+		case <-timeout.C:
+			return
+		}
+	}
+}
+
+// TestRecursiveWatcherRootEvent tests that modifications directly in
+// the watch root (not in a subdirectory) produce an event with an
+// empty relative path. This exercises the path == target branch in
+// the event processing loop.
+func TestRecursiveWatcherRootEvent(t *testing.T) {
+	// Skip this test if recursive watching is unsupported.
+	if !RecursiveWatchingSupported {
+		t.Skip()
+	}
+
+	// Create a temporary directory and establish a recursive watch.
+	directory := t.TempDir()
+	watcher, err := NewRecursiveWatcher(directory)
+	if err != nil {
+		t.Fatal("unable to establish watch:", err)
+	}
+	defer watcher.Terminate()
+
+	// Create a file directly in the watch root. The watcher should
+	// report this as a root-relative path (i.e. just the filename,
+	// not a subdirectory-prefixed path).
+	fileName := "root-level-file"
+	filePath := filepath.Join(directory, fileName)
+	if err := os.WriteFile(filePath, []byte("content"), 0600); err != nil {
+		t.Fatal("unable to create root-level file:", err)
+	}
+	verifyWatchEvent(t, watcher, map[string]bool{fileName: true})
+}
+
+// TestRecursiveWatcherNestedCreation tests that creating a deeply
+// nested directory tree and writing a file at depth produces events
+// for intermediate directories and the leaf file. This verifies that
+// the recursive watching mechanism detects events at arbitrary depth,
+// not just the first level below the root.
+func TestRecursiveWatcherNestedCreation(t *testing.T) {
+	// Skip this test if recursive watching is unsupported.
+	if !RecursiveWatchingSupported {
+		t.Skip()
+	}
+
+	// Create a temporary directory and establish a recursive watch.
+	directory := t.TempDir()
+	watcher, err := NewRecursiveWatcher(directory)
+	if err != nil {
+		t.Fatal("unable to establish watch:", err)
+	}
+	defer watcher.Terminate()
+
+	// Create a nested directory tree three levels deep. We use
+	// os.MkdirAll to create the entire path at once, which is a
+	// common application pattern (e.g., package managers creating
+	// node_modules/pkg/lib). The watcher should detect events for
+	// the intermediate directories and the final directory.
+	nestedDir := filepath.Join(directory, "a", "b", "c")
+	if err := os.MkdirAll(nestedDir, 0700); err != nil {
+		t.Fatal("unable to create nested directories:", err)
+	}
+
+	// We expect at least the deepest new directory to be reported.
+	// FSEvents may coalesce intermediate directory events, so we
+	// only require the leaf. The verifyWatchEvent helper ignores
+	// any additional events beyond the required set.
+	//
+	// Note: expected relative paths use forward slashes because
+	// the watcher normalizes to forward slashes on all platforms
+	// (see watch_recursive_windows.go). Use filepath.Join only
+	// for absolute filesystem paths.
+	verifyWatchEvent(t, watcher, map[string]bool{
+		"a/b/c": true,
+	})
+
+	// Drain any coalesced events from the directory creation before
+	// moving to the file creation phase.
+	drainEvents(watcher)
+
+	// Write a file at the deepest level. This tests that the
+	// watcher can detect events at depth even after a burst of
+	// directory creation events.
+	fileRelative := "a/b/c/deep-file"
+	fileAbsolute := filepath.Join(directory, fileRelative)
+	if err := os.WriteFile(fileAbsolute, []byte("deep"), 0600); err != nil {
+		t.Fatal("unable to create deep file:", err)
+	}
+	verifyWatchEvent(t, watcher, map[string]bool{fileRelative: true})
+}
+
+// TestRecursiveWatcherRapidModifications tests that multiple rapid
+// writes to the same file are detected. FSEvents coalesces events
+// within a latency window, so rapid modifications may arrive as a
+// single coalesced event rather than one per write. The key
+// correctness property is that *at least one* event is delivered
+// after the final modification, ensuring the synchronization engine
+// knows to rescan.
+func TestRecursiveWatcherRapidModifications(t *testing.T) {
+	// Skip this test if recursive watching is unsupported.
+	if !RecursiveWatchingSupported {
+		t.Skip()
+	}
+
+	// Create a temporary directory and establish a recursive watch.
+	directory := t.TempDir()
+	watcher, err := NewRecursiveWatcher(directory)
+	if err != nil {
+		t.Fatal("unable to establish watch:", err)
+	}
+	defer watcher.Terminate()
+
+	// Create the initial file so the watcher has something to track.
+	fileRelative := "rapid-file"
+	fileAbsolute := filepath.Join(directory, fileRelative)
+	if err := os.WriteFile(fileAbsolute, []byte("v1"), 0600); err != nil {
+		t.Fatal("unable to create file:", err)
+	}
+	verifyWatchEvent(t, watcher, map[string]bool{fileRelative: true})
+
+	// Drain events from the initial creation before starting the
+	// rapid modification burst.
+	drainEvents(watcher)
+
+	// Perform several rapid writes in quick succession without
+	// waiting for events between them. This simulates an editor
+	// auto-saving or a build tool writing multiple output files.
+	for i := range 10 {
+		data := []byte("version-" + string(rune('0'+i)))
+		if err := os.WriteFile(fileAbsolute, data, 0600); err != nil {
+			t.Fatalf("unable to write modification %d: %v", i, err)
+		}
+	}
+
+	// Verify that we receive at least one event for the file. Due
+	// to FSEvents coalescing, we may not receive 10 separate events,
+	// but we must receive at least one to ensure the sync engine
+	// would trigger a rescan.
+	verifyWatchEvent(t, watcher, map[string]bool{fileRelative: true})
+}
+
+// TestRecursiveWatcherRename tests that renaming a file within the
+// watched directory tree produces events. Rename is a common
+// operation pattern: many editors and tools use write-to-temp +
+// rename-over-target for atomic file updates. The watcher must
+// detect the rename so that the synchronization engine rescans the
+// affected paths.
+func TestRecursiveWatcherRename(t *testing.T) {
+	// Skip this test if recursive watching is unsupported.
+	if !RecursiveWatchingSupported {
+		t.Skip()
+	}
+
+	// Create a temporary directory and establish a recursive watch.
+	directory := t.TempDir()
+	watcher, err := NewRecursiveWatcher(directory)
+	if err != nil {
+		t.Fatal("unable to establish watch:", err)
+	}
+	defer watcher.Terminate()
+
+	// Create the source file.
+	sourceRelative := "source-file"
+	sourceAbsolute := filepath.Join(directory, sourceRelative)
+	if err := os.WriteFile(sourceAbsolute, []byte("rename-me"), 0600); err != nil {
+		t.Fatal("unable to create source file:", err)
+	}
+	verifyWatchEvent(t, watcher, map[string]bool{sourceRelative: true})
+
+	// Drain events from the creation before performing the rename.
+	drainEvents(watcher)
+
+	// Rename the file to a new name. FSEvents should report events
+	// for at least the destination path. It may also report an event
+	// for the source path (as a delete) depending on coalescing, but
+	// we only require the destination to be reported since that's the
+	// path the sync engine needs to rescan.
+	destRelative := "destination-file"
+	destAbsolute := filepath.Join(directory, destRelative)
+	if err := os.Rename(sourceAbsolute, destAbsolute); err != nil {
+		t.Fatal("unable to rename file:", err)
+	}
+	verifyWatchEvent(t, watcher, map[string]bool{destRelative: true})
+
+	// Drain events from the rename before performing the atomic
+	// replace pattern.
+	drainEvents(watcher)
+
+	// Test the atomic replace pattern: write to a temp file, then
+	// rename over an existing file. This is how many editors save
+	// files (e.g., Vim, VS Code) and is the most critical rename
+	// pattern for development workflows.
+	tempRelative := "temp-file"
+	tempAbsolute := filepath.Join(directory, tempRelative)
+	if err := os.WriteFile(tempAbsolute, []byte("new-content"), 0600); err != nil {
+		t.Fatal("unable to create temp file:", err)
+	}
+	verifyWatchEvent(t, watcher, map[string]bool{tempRelative: true})
+	drainEvents(watcher)
+
+	// Rename the temp file over the destination file. The watcher
+	// must detect this so the sync engine picks up the new content.
+	if err := os.Rename(tempAbsolute, destAbsolute); err != nil {
+		t.Fatal("unable to rename temp over destination:", err)
+	}
+	verifyWatchEvent(t, watcher, map[string]bool{destRelative: true})
+}
+
 // TestNonRecursiveWatcher tests the platform's NonRecursiveWatcher
 // implementation (if any) with a simple set of filesystem operations.
 func TestNonRecursiveWatcher(t *testing.T) {

--- a/pkg/mutagen/licenses.go
+++ b/pkg/mutagen/licenses.go
@@ -312,9 +312,7 @@ fsevents
 
 https://github.com/fsnotify/fsevents
 
-Forked and modified at https://github.com/mutagen-io/fsevents.
-
-Copyright (c) 2014 The fsevents Authors. All rights reserved.
+Copyright The fsevents Authors. All rights reserved.
 
 Used under the terms of the 3-Clause BSD License (Google version). A copy of
 this license can be found later in this text and a templated version can be


### PR DESCRIPTION
## Summary

Replace the `github.com/mutagen-io/fsevents` fork with the upstream
`github.com/fsnotify/fsevents` v0.2.0.

The fork was created when upstream was unmaintained. Upstream has
since been revived with significant improvements:

- `FSEventStreamStart` failures are now surfaced as errors (the fork
  silently swallowed them, which could produce a watcher that never
  delivered events)
- Implementation moved to dispatch queues (from the deprecated
  RunLoop API, eliminating the CFRunLoop race condition the fork
  patched)

All fork-only patches are superseded by upstream changes (see commit
message for details).

Also expands recursive watcher test coverage with four new tests:
root-level events, deeply nested directory creation, rapid
sequential modifications (coalescing behavior), and file renames
(including the atomic write-then-rename-over pattern common in
editors).

## Changes

- `go.mod` / `go.sum`: swap `mutagen-io/fsevents` for
  `fsnotify/fsevents v0.2.0`
- `pkg/filesystem/watching/watch_recursive_darwin_cgo.go`: update
  import, handle `watch.Start()` returning an error
- `pkg/filesystem/watching/watch_test.go`: add four new recursive
  watcher tests
- `pkg/mutagen/licenses.go`: update copyright to match upstream

## Test plan

- [x] `go test ./pkg/filesystem/watching/ -run TestRecursive`
      passes (5/5 tests including 4 new)
- [x] `go build ./cmd/... ./pkg/...` passes
- [x] `go vet ./cmd/... ./pkg/...` passes clean
- [x] License check: upstream BSD-3-Clause, no embedded third-party
      code
- [x] All fork patches verified superseded by upstream
- [x] CI passes on all platforms (macOS is the primary platform)