### PR TITLE
Add slim/full CI modes with merge queue support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@
 name: CI
 
 # Execute the workflow on pushes to primary/release branches, version
-# tag pushes, pull requests, and manual dispatch.
+# tag pushes, pull requests, merge queue, and manual dispatch.
 on:
   push:
     branches:
@@ -11,6 +11,7 @@ on:
     tags:
       - 'v*'
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 # Restrict default token permissions. Jobs that need write access
@@ -24,8 +25,70 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref_type != 'tag' }}
 
+# Determine whether this is a "full" CI run (release builds, code
+# signing, sidecar images, artifact upload) or a "slim" run (analysis,
+# tests, and slim builds only). Full CI runs on merge queue, tags,
+# master/release pushes, and manual dispatch. PR CI is slim.
+env:
+  FULL_CI: >-
+    ${{
+      github.event_name == 'merge_group' ||
+      github.ref_type == 'tag' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && (
+        github.ref == 'refs/heads/master' ||
+        startsWith(github.ref, 'refs/heads/release-branch-')
+      ))
+    }}
+
 # Define the workflow jobs.
 jobs:
+  # Detect which areas of the codebase have changed. This is used to
+  # conditionally run expensive steps (Docker transport tests, sidecar
+  # builds) in slim CI when their relevant files change.
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      docker: ${{ steps.detect.outputs.docker }}
+      sidecar: ${{ steps.detect.outputs.sidecar }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: "Detect changed areas"
+        id: detect
+        run: |
+          # Determine the base ref for comparison. For pull requests
+          # and merge queue, compare against the base branch. For
+          # pushes, compare against the previous commit.
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+          elif [[ "${{ github.event_name }}" == "merge_group" ]]; then
+            BASE="${{ github.event.merge_group.base_sha }}"
+          else
+            BASE="${{ github.event.before }}"
+          fi
+
+          # Get the list of changed files.
+          CHANGED=$(git diff --name-only "${BASE}..HEAD" 2>/dev/null || echo "")
+
+          # Detect Docker transport changes (pkg/docker, transport
+          # code, integration tests, CI Docker setup).
+          if echo "${CHANGED}" | grep -qiE 'docker|pkg/integration'; then
+            echo "docker=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "docker=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Detect sidecar-related changes (Dockerfile, sidecar
+          # package, CI build scripts).
+          if echo "${CHANGED}" | grep -qiE 'sidecar|images/|Dockerfile'; then
+            echo "sidecar=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "sidecar=false" >> "$GITHUB_OUTPUT"
+          fi
   verification:
     name: Commit Verification
     runs-on: ubuntu-latest
@@ -59,8 +122,11 @@ jobs:
       - run: scripts/ci/setup_partitions_darwin.sh
       - run: scripts/ci/analyze.sh
       - run: scripts/ci/test.sh
+        env:
+          MUTAGEN_CI_SKIP_RACE: ${{ env.FULL_CI != 'true' }}
       - run: scripts/ci/build.sh
         env:
+          MUTAGEN_CI_FULL_BUILD: ${{ env.FULL_CI }}
           MACOS_CODESIGN_IDENTITY: ${{ secrets.MACOS_CODESIGN_IDENTITY }}
           MACOS_CODESIGN_CERTIFICATE_AND_KEY: ${{ secrets.MACOS_CODESIGN_CERTIFICATE_AND_KEY }}
           MACOS_CODESIGN_CERTIFICATE_AND_KEY_PASSWORD: ${{ secrets.MACOS_CODESIGN_CERTIFICATE_AND_KEY_PASSWORD }}
@@ -71,6 +137,7 @@ jobs:
           MACOS_NOTARIZE_APP_SPECIFIC_PASSWORD: ${{ secrets.MACOS_NOTARIZE_APP_SPECIFIC_PASSWORD }}
           MACOS_NOTARIZE_TEAM_ID: ${{ secrets.MACOS_NOTARIZE_TEAM_ID }}
       - run: scripts/ci/sha256sum.sh
+        if: env.FULL_CI == 'true'
       - uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
         id: import_gpg
         if: github.ref_type == 'tag'
@@ -110,6 +177,7 @@ jobs:
   windows:
     name: Windows
     runs-on: windows-latest
+    needs: [changes]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -119,6 +187,7 @@ jobs:
       - run: scripts/ci/setup_go.sh
         shell: bash
       - run: scripts/ci/setup_docker.sh
+        if: env.FULL_CI == 'true' || needs.changes.outputs.docker == 'true'
         shell: bash
       - name: "Prepare Windows partition script"
         run: |
@@ -136,6 +205,9 @@ jobs:
         shell: bash
       - run: scripts/ci/test.sh
         shell: bash
+        env:
+          MUTAGEN_CI_SKIP_RACE: ${{ env.FULL_CI != 'true' }}
+          MUTAGEN_CI_SKIP_DOCKER: ${{ env.FULL_CI != 'true' && needs.changes.outputs.docker != 'true' }}
       - run: scripts/ci/test_386.sh
         shell: bash
       - run: scripts/ci/build.sh
@@ -143,7 +215,16 @@ jobs:
   sidecar:
     name: Sidecar
     runs-on: ubuntu-latest
-    needs: [macos, linux, windows]
+    if: >-
+      github.event_name == 'merge_group' ||
+      github.ref_type == 'tag' ||
+      github.event_name == 'workflow_dispatch' ||
+      needs.changes.outputs.sidecar == 'true' ||
+      (github.event_name == 'push' && (
+        github.ref == 'refs/heads/master' ||
+        startsWith(github.ref, 'refs/heads/release-branch-')
+      ))
+    needs: [changes, macos, linux, windows]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,44 +51,23 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
-      docker: ${{ steps.detect.outputs.docker }}
-      sidecar: ${{ steps.detect.outputs.sidecar }}
+      run_windows_docker: ${{ steps.detect.outputs.run_windows_docker }}
+      run_sidecar: ${{ steps.detect.outputs.run_sidecar }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - name: "Detect changed areas"
+      - name: "Plan optional CI work"
         id: detect
-        run: |
-          # Determine the base ref for comparison. For pull requests
-          # and merge queue, compare against the base branch. For
-          # pushes, compare against the previous commit.
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            BASE="${{ github.event.pull_request.base.sha }}"
-          elif [[ "${{ github.event_name }}" == "merge_group" ]]; then
-            BASE="${{ github.event.merge_group.base_sha }}"
-          else
-            BASE="${{ github.event.before }}"
-          fi
-
-          # Get the list of changed files.
-          CHANGED=$(git diff --name-only "${BASE}..HEAD" 2>/dev/null || echo "")
-
-          # Detect Docker transport changes (pkg/docker, transport
-          # code, integration tests, CI Docker setup).
-          if echo "${CHANGED}" | grep -qiE 'docker|pkg/integration'; then
-            echo "docker=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "docker=false" >> "$GITHUB_OUTPUT"
-          fi
-
-          # Detect sidecar-related changes (Dockerfile, sidecar
-          # package, CI build scripts).
-          if echo "${CHANGED}" | grep -qiE 'sidecar|images/|Dockerfile'; then
-            echo "sidecar=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "sidecar=false" >> "$GITHUB_OUTPUT"
-          fi
+        env:
+          MUTAGEN_CI_EVENT_NAME: ${{ github.event_name }}
+          MUTAGEN_CI_FULL: ${{ env.FULL_CI }}
+          MUTAGEN_CI_PULL_REQUEST_BASE_SHA: >-
+            ${{ github.event.pull_request.base.sha }}
+          MUTAGEN_CI_MERGE_GROUP_BASE_SHA: >-
+            ${{ github.event.merge_group.base_sha }}
+          MUTAGEN_CI_PUSH_BASE_SHA: ${{ github.event.before }}
+        run: scripts/ci/detect_changes.sh
   verification:
     name: Commit Verification
     runs-on: ubuntu-latest
@@ -187,7 +166,7 @@ jobs:
       - run: scripts/ci/setup_go.sh
         shell: bash
       - run: scripts/ci/setup_docker.sh
-        if: env.FULL_CI == 'true' || needs.changes.outputs.docker == 'true'
+        if: needs.changes.outputs.run_windows_docker == 'true'
         shell: bash
       - name: "Prepare Windows partition script"
         run: |
@@ -207,7 +186,10 @@ jobs:
         shell: bash
         env:
           MUTAGEN_CI_SKIP_RACE: ${{ env.FULL_CI != 'true' }}
-          MUTAGEN_CI_SKIP_DOCKER: ${{ env.FULL_CI != 'true' && needs.changes.outputs.docker != 'true' }}
+          MUTAGEN_CI_SKIP_DOCKER: >-
+            ${{
+              needs.changes.outputs.run_windows_docker != 'true'
+            }}
       - run: scripts/ci/test_386.sh
         shell: bash
       - run: scripts/ci/build.sh
@@ -215,15 +197,7 @@ jobs:
   sidecar:
     name: Sidecar
     runs-on: ubuntu-latest
-    if: >-
-      github.event_name == 'merge_group' ||
-      github.ref_type == 'tag' ||
-      github.event_name == 'workflow_dispatch' ||
-      needs.changes.outputs.sidecar == 'true' ||
-      (github.event_name == 'push' && (
-        github.ref == 'refs/heads/master' ||
-        startsWith(github.ref, 'refs/heads/release-branch-')
-      ))
+    if: needs.changes.outputs.run_sidecar == 'true'
     needs: [changes, macos, linux, windows]
     timeout-minutes: 30
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,8 +8,10 @@ follow the code and update this file.
 
 - `README.md` provides the public project overview.
 - `BUILDING.md` describes the build flow and protobuf regeneration.
-- `CONTRIBUTING.md` defines coding style, testing expectations, DCO
-  requirements, and commit message guidelines.
+- `TESTING.md` describes the test infrastructure, environment
+  variables, platform-specific behavior, and CI pipeline modes.
+- `CONTRIBUTING.md` defines coding style, DCO requirements, and
+  commit message guidelines.
 - `SECURITY.md` defines the security reporting process.
 - `scripts/build.go` is the source of truth for build modes and the
   main platform matrix.
@@ -86,12 +88,8 @@ follow the code and update this file.
 - Sidecar binaries and images are built via `cmd/mutagen-sidecar`,
   `scripts/ci/build.sh`, and `images/sidecar/linux/Dockerfile`.
 - Run package tests sequentially with `go test -p 1 ./pkg/...`.
-- In sandboxes or other restricted environments, set
-  `MUTAGEN_DATA_DIRECTORY` to a writable absolute path before
-  running tests. Development builds default to `~/.mutagen-dev`;
-  release builds use `~/.mutagen`.
-- Run `go test -v -tags mutagensspl ./sspl/...` when touching
-  SSPL code.
+  See `TESTING.md` for full details on test environment variables,
+  platform-specific behavior, and CI modes.
 
 ## Generated Code And Dependencies
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,145 @@
+# Testing
+
+This document describes how Mutagen's tests are structured, how to run
+them locally, and how CI exercises them.
+
+
+## Running Tests Locally
+
+### Basic test run
+
+All package tests must be run sequentially due to shared daemon state
+and IPC endpoints:
+
+    go test -p 1 ./pkg/...
+
+The `-p 1` flag is required. Parallel test execution will cause
+failures due to daemon lock contention and IPC socket conflicts.
+
+### Integration tests
+
+Integration tests require a local agent bundle to be built first:
+
+    go run scripts/build.go --mode=local
+    MUTAGEN_TEST_END_TO_END=full go test -p 1 ./pkg/...
+
+Without `MUTAGEN_TEST_END_TO_END`, integration tests are skipped.
+The `full` value runs all integration tests; `slim` runs a reduced
+set suitable for race detection.
+
+### SSPL tests
+
+Tests for SSPL-licensed code (fanotify, xxh128, zstd) are gated
+behind a build tag:
+
+    go test -v -tags mutagensspl ./sspl/...
+
+### Race detection
+
+Run with the race detector enabled using a slim integration test
+set (the race detector significantly increases execution time):
+
+    MUTAGEN_TEST_END_TO_END=slim go test -p 1 -race ./pkg/...
+
+### Data directory
+
+Mutagen tests use `~/.mutagen-dev` for development builds and
+`~/.mutagen` for release builds. In sandboxed or restricted
+environments, set `MUTAGEN_DATA_DIRECTORY` to a writable absolute
+path before running tests.
+
+
+## Environment Variables
+
+The following variables control test behavior and scope:
+
+| Variable | Values | Effect |
+|----------|--------|--------|
+| `MUTAGEN_TEST_END_TO_END` | `full`, `slim` | Enables end-to-end integration tests. `full` runs all integration tests; `slim` runs a reduced set. |
+| `MUTAGEN_TEST_SSH` | `true` | Enables SSH transport tests. Requires a local SSH server accepting connections to `localhost`. |
+| `MUTAGEN_TEST_DOCKER` | `true` | Enables Docker transport tests. Requires a running Docker daemon and a pre-built test container (see `scripts/ci/setup_docker.sh`). |
+| `MUTAGEN_TEST_DOCKER_CONTAINER_NAME` | name | Specifies the Docker container name for transport tests (typically `mutagentester`). |
+| `MUTAGEN_TEST_DOCKER_USERNAME` | name | Specifies the user inside the Docker test container (Windows only). |
+| `MUTAGEN_TEST_ENABLE_SSPL` | `true` | Includes SSPL-licensed code in the main test run (adds `-tags mutagensspl`). |
+| `MUTAGEN_TEST_FAT32_ROOT` | path | macOS/Windows: path to a FAT32 filesystem root for filesystem behavior tests. |
+| `MUTAGEN_TEST_HFS_ROOT` | path | macOS: path to an HFS+ filesystem root. |
+| `MUTAGEN_TEST_APFS_ROOT` | path | macOS: path to an APFS filesystem root. |
+| `MUTAGEN_TEST_SUBFS_ROOT` | path | macOS: path to an HFS+ subfilesystem mounted under APFS. |
+| `MUTAGEN_DATA_DIRECTORY` | path | Overrides the default Mutagen data directory for tests. |
+
+
+## Platform-Specific Behavior
+
+Tests vary by platform due to filesystem capabilities, transport
+availability, and SSPL support:
+
+| Aspect | macOS | Linux | Windows |
+|--------|-------|-------|---------|
+| **SSPL tests** | Disabled in main run | Enabled | Disabled in main run |
+| **SSH transport** | Tested | Tested | Not tested |
+| **Docker transport** | Not tested | Tested | Tested |
+| **Race detection** | Full CI only | Always | Full CI only |
+| **386-bit tests** | Not available | Always | Always |
+| **Filesystem partitions** | FAT32, HFS+, APFS | None | FAT32 |
+
+SSPL tests (`go test -tags mutagensspl ./sspl/...`) run separately
+on all platforms regardless of the per-platform `MUTAGEN_TEST_ENABLE_SSPL`
+setting.
+
+See `scripts/ci/test_parameters.sh` for the exact per-platform
+configuration.
+
+
+## CI Pipeline
+
+CI runs on GitHub Actions with two modes:
+
+### Slim mode (pull requests)
+
+Optimized for fast feedback on PR iterations:
+
+- Analysis (`gofmt`, `go vet`, `go mod tidy` check) on all platforms.
+- Full test suite with coverage profiling on all platforms.
+- Race detection on Linux only (skipped on macOS and Windows).
+- 386-bit tests on Linux and Windows.
+- Slim builds (common platforms only) on all platforms.
+- Docker transport tests on Windows skipped unless Docker-related
+  files changed.
+- Sidecar multi-platform builds skipped unless sidecar-related
+  files changed.
+
+### Full mode (merge queue, tags, master/release pushes, manual)
+
+Complete validation before code lands:
+
+- Everything in slim mode, plus:
+- Race detection on all platforms.
+- Docker transport tests on all platforms unconditionally.
+- Full release cross-compilation on macOS (all target platforms,
+  code signing when credentials are available).
+- Sidecar multi-platform Docker image builds.
+- SHA256 checksums and GPG signing (tag builds only).
+- Notarization (tag builds only).
+- Release artifact upload (tag builds only).
+
+### CI environment variables
+
+These variables are set by the CI workflow to control test behavior:
+
+| Variable | Set When | Effect |
+|----------|----------|--------|
+| `MUTAGEN_CI_SKIP_RACE` | `true` | Slim CI on macOS/Windows. Skips the race detection test pass. |
+| `MUTAGEN_CI_SKIP_DOCKER` | `true` | Slim CI on Windows when Docker files unchanged. Disables Docker transport tests. |
+| `MUTAGEN_CI_FULL_BUILD` | `true` | Full CI on macOS. Switches from slim to release cross-compilation. |
+
+### Change detection
+
+A lightweight "Detect Changes" preamble job determines which areas
+of the codebase changed in the PR:
+
+- **docker**: Files matching `docker` or `pkg/integration` changed.
+  Triggers Docker transport tests on Windows even in slim mode.
+- **sidecar**: Files matching `sidecar`, `images/`, or `Dockerfile`
+  changed. Triggers sidecar builds even in slim mode.
+
+See `.github/workflows/ci.yml` for the full CI configuration.

--- a/TESTING.md
+++ b/TESTING.md
@@ -134,12 +134,18 @@ These variables are set by the CI workflow to control test behavior:
 
 ### Change detection
 
-A lightweight "Detect Changes" preamble job determines which areas
-of the codebase changed in the PR:
+A lightweight "Detect Changes" preamble job runs
+`scripts/ci/detect_changes.sh` and emits final booleans for optional
+CI work:
 
-- **docker**: Files matching `docker` or `pkg/integration` changed.
-  Triggers Docker transport tests on Windows even in slim mode.
-- **sidecar**: Files matching `sidecar`, `images/`, or `Dockerfile`
-  changed. Triggers sidecar builds even in slim mode.
+- **`run_windows_docker`**: True in full CI, or when Docker
+  transport-related files change in slim CI. This currently includes
+  the workflow itself plus `pkg/docker`, `pkg/integration`,
+  `scripts/ci/docker`, `scripts/ci/setup_docker.sh`,
+  `scripts/ci/test.sh`, and `scripts/ci/test_parameters.sh`.
+- **`run_sidecar`**: True in full CI, or when sidecar image inputs
+  change in slim CI. This currently includes the workflow itself plus
+  `cmd/mutagen-sidecar`, `pkg/sidecar`, `images/sidecar`, and
+  `scripts/ci/sidecar_tag.go`.
 
 See `.github/workflows/ci.yml` for the full CI configuration.

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -6,29 +6,34 @@ set -e
 # Determine the operating system.
 MUTAGEN_OS_NAME="$(go env GOOS)"
 
-# Perform a build that's appropriate for the platform.
-if [[ "${MUTAGEN_OS_NAME}" == "darwin" ]]; then
-    # Check if code signing is possible. If so, then set up the keychain and
-    # certificates that we'll need and perform a signed build. If not, then just
-    # perform a normal build.
+# Perform a build that's appropriate for the platform. On macOS, full
+# CI runs perform a complete release cross-compilation (with optional
+# code signing), while slim CI runs use the default slim build mode.
+# On other platforms, slim builds are always used.
+if [[ "${MUTAGEN_OS_NAME}" == "darwin" && "${MUTAGEN_CI_FULL_BUILD}" == "true" ]]; then
+    # Check if code signing is possible. If so, then set up the
+    # keychain and certificates that we'll need and perform a signed
+    # build. If not, then just perform a normal build.
     if [[ ! -z "${MACOS_CODESIGN_IDENTITY}" ]]; then
-        # Compute the path and password for a temporary keychain where we'll import
-        # the macOS code signing certificate and private key.
+        # Compute the path and password for a temporary keychain
+        # where we'll import the macOS code signing certificate and
+        # private key.
         MUTAGEN_KEYCHAIN_PATH="${RUNNER_TEMP}/mutagen.keychain-db"
         MUTAGEN_KEYCHAIN_PASSWORD="$(dd if=/dev/random bs=1024 count=1 2>/dev/null | openssl dgst -sha256)"
 
         # Store the previous default keychain.
         PREVIOUS_DEFAULT_KEYCHAIN="$(security default-keychain | xargs)"
 
-        # Create the temporary keychain, set it to be the default keychain, set it
-        # to automatically re-lock (just in case removal fails), and unlock it.
+        # Create the temporary keychain, set it to be the default
+        # keychain, set it to automatically re-lock (just in case
+        # removal fails), and unlock it.
         security create-keychain -p "${MUTAGEN_KEYCHAIN_PASSWORD}" "${MUTAGEN_KEYCHAIN_PATH}"
         security default-keychain -s "${MUTAGEN_KEYCHAIN_PATH}"
         security set-keychain-settings -lut 3600 "${MUTAGEN_KEYCHAIN_PATH}"
         security unlock-keychain -p "${MUTAGEN_KEYCHAIN_PASSWORD}" "${MUTAGEN_KEYCHAIN_PATH}"
 
-        # Import the macOS code signing certificate and private key and allow access
-        # from the codesign utility.
+        # Import the macOS code signing certificate and private key
+        # and allow access from the codesign utility.
         MUTAGEN_CERTIFICATE_AND_KEY_PATH="${RUNNER_TEMP}/certificate_and_key.p12"
         echo -n "${MACOS_CODESIGN_CERTIFICATE_AND_KEY}" | base64 --decode --output "${MUTAGEN_CERTIFICATE_AND_KEY_PATH}"
         security import "${MUTAGEN_CERTIFICATE_AND_KEY_PATH}" -k "${MUTAGEN_KEYCHAIN_PATH}" -P "${MACOS_CODESIGN_CERTIFICATE_AND_KEY_PASSWORD}" -T "/usr/bin/codesign"
@@ -39,12 +44,13 @@ if [[ "${MUTAGEN_OS_NAME}" == "darwin" ]]; then
         # SSPL-licensed extensions by default.
         go run scripts/build.go --mode=release --sspl --macos-codesign-identity="${MACOS_CODESIGN_IDENTITY}"
 
-        # Reset the default keychain and remove the temporary keychain.
+        # Reset the default keychain and remove the temporary
+        # keychain.
         security default-keychain -s "${PREVIOUS_DEFAULT_KEYCHAIN}"
         security delete-keychain "${MUTAGEN_KEYCHAIN_PATH}"
     else
-        # Perform a full release build without code signing. We enable
-        # SSPL-licensed extensions by default.
+        # Perform a full release build without code signing. We
+        # enable SSPL-licensed extensions by default.
         go run scripts/build.go --mode=release --sspl
     fi
 
@@ -66,7 +72,8 @@ if [[ "${MUTAGEN_OS_NAME}" == "darwin" ]]; then
     zip "build/release/mutagen_windows_arm64_v${MUTAGEN_VERSION}.zip" mutagen.exe mutagen-agents.tar.gz
     rm mutagen.exe mutagen-agents.tar.gz
 else
-    # Perform a slim build. We enable SSPL-licensed extensions by default.
+    # Perform a slim build. We enable SSPL-licensed extensions by
+    # default.
     go run scripts/build.go --mode=slim --sspl
 fi
 

--- a/scripts/ci/detect_changes.sh
+++ b/scripts/ci/detect_changes.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+# Exit immediately on failure.
+set -e
+
+# write_output writes a workflow output. When running locally, it falls back to
+# stdout so that the script remains easy to inspect and debug.
+write_output() {
+    local name="$1"
+    local value="$2"
+
+    if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+        echo "${name}=${value}" >> "${GITHUB_OUTPUT}"
+    else
+        echo "${name}=${value}"
+    fi
+}
+
+# write_plan writes the final booleans that control optional CI work.
+write_plan() {
+    local run_windows_docker="$1"
+    local run_sidecar="$2"
+
+    write_output "run_windows_docker" "${run_windows_docker}"
+    write_output "run_sidecar" "${run_sidecar}"
+}
+
+# determine_base identifies the comparison base for change detection. Pull
+# requests use their merge base with the target branch so that unrelated base
+# branch changes do not affect the result.
+determine_base() {
+    if [[ "${MUTAGEN_CI_EVENT_NAME}" == "pull_request" ]]; then
+        git merge-base HEAD "${MUTAGEN_CI_PULL_REQUEST_BASE_SHA}"
+    elif [[ "${MUTAGEN_CI_EVENT_NAME}" == "merge_group" ]]; then
+        echo "${MUTAGEN_CI_MERGE_GROUP_BASE_SHA}"
+    else
+        echo "${MUTAGEN_CI_PUSH_BASE_SHA}"
+    fi
+}
+
+# has_changes checks whether any of the specified paths differ from the
+# comparison base.
+has_changes() {
+    ! git diff --quiet "${MUTAGEN_CI_BASE}..HEAD" -- "$@"
+}
+
+# Full CI always enables all optional work, so no path-based planning is
+# necessary in that case.
+if [[ "${MUTAGEN_CI_FULL}" == "true" ]]; then
+    echo "Full CI requested; enabling all optional work."
+    write_plan "true" "true"
+    exit 0
+fi
+
+# Determine and validate the comparison base. If the base cannot be resolved,
+# then err on the side of running the optional work.
+MUTAGEN_CI_BASE="$(determine_base)"
+if [[ -z "${MUTAGEN_CI_BASE}" ]]; then
+    echo "Unable to determine a comparison base; enabling all optional work."
+    write_plan "true" "true"
+    exit 0
+fi
+
+if ! git rev-parse --verify "${MUTAGEN_CI_BASE}^{commit}" >/dev/null 2>&1; then
+    echo "Unable to resolve comparison base; enabling all optional work."
+    write_plan "true" "true"
+    exit 0
+fi
+
+echo "Comparing ${MUTAGEN_CI_BASE}..HEAD for optional CI work."
+
+# Detect whether Windows Docker transport coverage should run in slim CI. The
+# workflow file is included so that changes to the gating logic exercise the
+# path they control.
+RUN_WINDOWS_DOCKER="false"
+if has_changes \
+    .github/workflows/ci.yml \
+    pkg/docker \
+    pkg/integration \
+    scripts/ci/docker \
+    scripts/ci/setup_docker.sh \
+    scripts/ci/test.sh \
+    scripts/ci/test_parameters.sh
+then
+    RUN_WINDOWS_DOCKER="true"
+fi
+
+# Detect whether the sidecar image build should run in slim CI. The workflow
+# file is included for the same reason as above.
+RUN_SIDECAR="false"
+if has_changes \
+    .github/workflows/ci.yml \
+    cmd/mutagen-sidecar \
+    pkg/sidecar \
+    images/sidecar \
+    scripts/ci/sidecar_tag.go
+then
+    RUN_SIDECAR="true"
+fi
+
+# Write the final plan.
+write_plan "${RUN_WINDOWS_DOCKER}" "${RUN_SIDECAR}"

--- a/scripts/ci/test.sh
+++ b/scripts/ci/test.sh
@@ -6,6 +6,14 @@ set -e
 # Load test parameters.
 source scripts/ci/test_parameters.sh
 
+# Allow CI to skip Docker transport tests (e.g., in slim mode on
+# Windows when Docker-related files haven't changed).
+if [[ "${MUTAGEN_CI_SKIP_DOCKER}" == "true" ]]; then
+    export MUTAGEN_TEST_DOCKER="false"
+    unset MUTAGEN_TEST_DOCKER_CONTAINER_NAME
+    unset MUTAGEN_TEST_DOCKER_USERNAME
+fi
+
 # Perform a local build so that we have an agent bundle for integration tests.
 if [[ "${MUTAGEN_TEST_ENABLE_SSPL}" == "true" ]]; then
     go run scripts/build.go --mode=local --sspl
@@ -20,12 +28,17 @@ else
     go test -p 1 -v -coverpkg=./pkg/... -coverprofile=coverage.txt ./pkg/...
 fi
 
-# Run tests with the race detector enabled. We use a slim end-to-end test since
-# the race detector significantly increases the execution time.
-if [[ "${MUTAGEN_TEST_ENABLE_SSPL}" == "true" ]]; then
-    MUTAGEN_TEST_END_TO_END="slim" go test -tags mutagensspl -p 1 -race ./pkg/...
-else
-    MUTAGEN_TEST_END_TO_END="slim" go test -p 1 -race ./pkg/...
+# Run tests with the race detector enabled. We use a slim end-to-end
+# test since the race detector significantly increases the execution
+# time. This step can be skipped in slim CI on platforms where race
+# detection adds significant overhead (macOS, Windows), since Linux
+# CI already provides race detection coverage.
+if [[ "${MUTAGEN_CI_SKIP_RACE}" != "true" ]]; then
+    if [[ "${MUTAGEN_TEST_ENABLE_SSPL}" == "true" ]]; then
+        MUTAGEN_TEST_END_TO_END="slim" go test -tags mutagensspl -p 1 -race ./pkg/...
+    else
+        MUTAGEN_TEST_END_TO_END="slim" go test -p 1 -race ./pkg/...
+    fi
 fi
 
 # Run tests on SSPL code. We perform this test on all platforms, regardless of


### PR DESCRIPTION
## Summary

Split CI into slim and full modes to speed up PR iteration while
maintaining release-quality validation before merge.

### Slim mode (PRs)

- Analysis, tests (including 386), and slim builds on all platforms
- Race detection skipped on macOS and Windows (Linux provides
  coverage)
- Windows Docker transport tests skipped unless Docker-related files
  changed (saves ~4 min of Windows container image pull)
- Sidecar multi-platform builds skipped unless sidecar-related files
  changed
- Skips: release cross-compilation, code signing, SHA256 checksums,
  artifact upload

### Full mode (merge queue, tags, master/release pushes, manual)

- Everything runs unconditionally

### Smart change detection

A lightweight "Detect Changes" preamble job runs `git diff` to
determine which areas of the codebase changed:
- **docker**: `pkg/docker`, `pkg/integration`, CI Docker setup
- **sidecar**: `images/`, `Dockerfile`, `pkg/sidecar`

These flags gate expensive slim-mode steps so they still run when
their relevant code changes, even outside the merge queue.

### Implementation

- `FULL_CI` env var computed at workflow level
- `MUTAGEN_CI_SKIP_RACE` env var skips race detection in `test.sh`
- `MUTAGEN_CI_SKIP_DOCKER` env var skips Docker tests in `test.sh`
- `MUTAGEN_CI_FULL_BUILD` env var selects release vs slim build
  in `build.sh`
- Sidecar job `if` condition checks both full CI and change detection
- New `merge_group` trigger for GitHub Merge Queue

## Test plan

- [ ] PR CI runs slim (this PR validates it)
- [ ] macOS job faster (no release cross-compilation)
- [ ] Windows job faster when Docker files unchanged (no Docker
      setup/tests)
- [ ] Sidecar job skipped when sidecar files unchanged
- [ ] Full CI validated on merge to master