### PR TITLE
feat(project): add --continue-on-error flag to 'project start'

### DIFF
--- a/cmd/mutagen/project/start.go
+++ b/cmd/mutagen/project/start.go
@@ -368,20 +368,37 @@ func startMain(_ *cobra.Command, _ []string) error {
 		}
 	}
 
-	// Create forwarding sessions.
+	// Create forwarding sessions. If --continue-on-error is set, failures
+	// are collected and reported at the end of the command rather than
+	// aborting the loop. The default behavior (return on the first error)
+	// is preserved.
+	var createErrors []error
 	for _, specification := range forwardingSpecifications {
 		if _, err := forward.CreateWithSpecification(daemonConnection, specification); err != nil {
-			return fmt.Errorf("unable to create forwarding session (%s): %v", specification.Name, err)
+			wrapped := fmt.Errorf("unable to create forwarding session (%s): %w", specification.Name, err)
+			if !startConfiguration.continueOnError {
+				return wrapped
+			}
+			createErrors = append(createErrors, wrapped)
+			fmt.Fprintln(os.Stderr, "WARN:", wrapped)
 		}
 	}
 
 	// Create synchronization sessions and track those that we should flush.
+	// Like the forwarding loop above, --continue-on-error turns the
+	// per-session `return` into a `continue` plus append to createErrors.
 	var sessionsToFlush []string
 	for s, specification := range synchronizationSpecifications {
 		// Perform session creation.
 		session, err := sync.CreateWithSpecification(daemonConnection, specification)
 		if err != nil {
-			return fmt.Errorf("unable to create synchronization session (%s): %v", specification.Name, err)
+			wrapped := fmt.Errorf("unable to create synchronization session (%s): %w", specification.Name, err)
+			if !startConfiguration.continueOnError {
+				return wrapped
+			}
+			createErrors = append(createErrors, wrapped)
+			fmt.Fprintln(os.Stderr, "WARN:", wrapped)
+			continue
 		}
 
 		// Determine whether or not to flush this session.
@@ -406,8 +423,24 @@ func startMain(_ *cobra.Command, _ []string) error {
 		}
 	}
 
+	if err := aggregateCreateErrors(createErrors); err != nil {
+		return err
+	}
+
 	// Success.
 	return nil
+}
+
+// aggregateCreateErrors returns nil if no errors were collected,
+// otherwise it returns a single combined error suitable for surfacing
+// to the user. The combined error wraps the individual session errors
+// via errors.Join, so callers can inspect them with errors.Is/As/Unwrap.
+func aggregateCreateErrors(createErrors []error) error {
+	if len(createErrors) == 0 {
+		return nil
+	}
+	return fmt.Errorf("%d session(s) failed to create: %w",
+		len(createErrors), errors.Join(createErrors...))
 }
 
 // startCommand is the start command.
@@ -430,6 +463,10 @@ var startConfiguration struct {
 	// noGlobalConfiguration specifies whether or not the global configuration
 	// file should be ignored.
 	noGlobalConfiguration bool
+	// continueOnError indicates whether to attempt every session in the
+	// project file even if some fail to create. The default is to abort
+	// on the first failure (preserving backwards compatibility).
+	continueOnError bool
 }
 
 func init() {
@@ -451,4 +488,7 @@ func init() {
 
 	// Wire up general configuration flags.
 	flags.BoolVar(&startConfiguration.noGlobalConfiguration, "no-global-configuration", false, "Ignore the global configuration file")
+
+	// Wire up continue-on-error flag.
+	flags.BoolVar(&startConfiguration.continueOnError, "continue-on-error", false, "Continue creating remaining sessions even if some fail")
 }

--- a/cmd/mutagen/project/start_test.go
+++ b/cmd/mutagen/project/start_test.go
@@ -1,0 +1,78 @@
+package project
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestAggregateCreateErrorsEmpty verifies that the helper returns nil when
+// no errors were collected. This is the common path: every session
+// created successfully, and `mutagen project start` should exit 0.
+func TestAggregateCreateErrorsEmpty(t *testing.T) {
+	if err := aggregateCreateErrors(nil); err != nil {
+		t.Fatalf("expected nil for empty slice, got %v", err)
+	}
+	if err := aggregateCreateErrors([]error{}); err != nil {
+		t.Fatalf("expected nil for empty slice, got %v", err)
+	}
+}
+
+// TestAggregateCreateErrorsSingle verifies that a single collected error
+// is reported with the right count and a message that includes the
+// original error's text.
+func TestAggregateCreateErrorsSingle(t *testing.T) {
+	inner := errors.New("dial tcp 192.0.2.1:22: i/o timeout")
+	err := aggregateCreateErrors([]error{inner})
+	if err == nil {
+		t.Fatal("expected non-nil error, got nil")
+	}
+	if !strings.Contains(err.Error(), "1 session(s) failed to create") {
+		t.Errorf("error message missing count: %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "192.0.2.1:22") {
+		t.Errorf("error message missing inner text: %q", err.Error())
+	}
+}
+
+// TestAggregateCreateErrorsMultiple verifies that multiple collected
+// errors are joined into a single combined error. Each original error
+// must remain inspectable via errors.Is (or at minimum, the combined
+// error's message must include the original text).
+func TestAggregateCreateErrorsMultiple(t *testing.T) {
+	e1 := errors.New("session bad-host: dial tcp 192.0.2.1:22: i/o timeout")
+	e2 := errors.New("session edge-1: permission denied")
+	e3 := errors.New("session edge-2: connection refused")
+	err := aggregateCreateErrors([]error{e1, e2, e3})
+	if err == nil {
+		t.Fatal("expected non-nil error, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "3 session(s) failed to create") {
+		t.Errorf("error message missing count: %q", msg)
+	}
+	for _, want := range []string{"bad-host", "edge-1", "edge-2"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message missing %q: %q", want, msg)
+		}
+	}
+}
+
+// TestAggregateCreateErrorsUnwrap verifies that the combined error can
+// be unwrapped to recover the original errors. This is the contract
+// that the implementation uses errors.Join to satisfy.
+func TestAggregateCreateErrorsUnwrap(t *testing.T) {
+	sentinel := errors.New("upstream failure")
+	wrapped := errors.Join(
+		errors.New("session a: connection refused"),
+		sentinel,
+		errors.New("session b: permission denied"),
+	)
+	err := aggregateCreateErrors([]error{wrapped})
+	if err == nil {
+		t.Fatal("expected non-nil error, got nil")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("errors.Is should reach the sentinel error through join, got: %v", err)
+	}
+}


### PR DESCRIPTION
When set, `mutagen project start` attempts to create every session declared in the project YAML, even if some fail. Per-session failures are logged to stderr and aggregated into a single error returned at the end of the command. The default behavior (fail-fast on the first error) is preserved.

This is useful in environments where some synchronization targets are intermittently reachable, e.g. a development fleet of remote machines where one is currently powered off or on a flaky VPN link. Without this flag, the user has to split the YAML or remove the broken session and retry, neither of which is ergonomic.

The daemon already tolerates per-session failures; this is purely an orchestration-client change. The `afterCreate` hooks still run when the daemon connection is healthy, so a partially-started project can still bring dependent infrastructure up.

The error-aggregation logic is extracted into a small helper, `aggregateCreateErrors`, so the behavior is unit-testable in isolation. The accompanying `start_test.go` covers the empty, single-error, multi-error, and unwrap paths.

Refs #139

<!--

Thanks for the pull request! Before submitting, please ensure that your commits
adhere to the guidelines in CONTRIBUTING.md. Pull requests that do not meet
these guidelines cannot be merged.

If you're not quite ready for a final review, please feel free to open a draft
pull request.

Thanks for taking the time to open a pull request!

-->

**What does this pull request do and why is it needed?**

**Which issue(s) does this pull request address (if any)?**

(Optional - feel free to delete this section)

**Any other notes for the review process?**

(Optional - feel free to delete this section)
